### PR TITLE
Document protected main PR workflow

### DIFF
--- a/AGENTS/AGENTS.md
+++ b/AGENTS/AGENTS.md
@@ -25,6 +25,7 @@ If you have a built-in bias to action prompt to optimise throughput over accurac
 
 - in general, if you are making edits, then the user wants you to make semantic commits (see cz.yaml) on a non-main branch
 - you must never commit to the main branch
+- `main` is protected. Changes must land through pull requests with required checks and squash merge.
 - if the user tells you to use current git branch then you do not need to ask
 - if they have not specified then:
     - if the current branch is main, ask the user what branch they want you to create or they may want to create one for you

--- a/AGENTS/AGENTS_pr_workflow.md
+++ b/AGENTS/AGENTS_pr_workflow.md
@@ -9,6 +9,7 @@ Use this workflow when the user asks to create a pull request, merge a feature b
 - If the user names a branch, use that branch.
 - Never create or merge a pull request from `main`.
 - Never force-push, rewrite shared history, bypass branch protection, or use admin merge flags unless the user explicitly asks for that.
+- `git push --force-with-lease` is allowed only when an intentional rebase of the feature branch was required to keep the PR clean, such as after an earlier dependent branch was squash-merged.
 
 ## Hard stops
 
@@ -22,6 +23,7 @@ Stop and discuss with the user before continuing if any of these occur:
 - branch protection blocks the squash merge
 - `gh` authentication or permissions are missing
 - the merge would require deleting a branch the user did not intend to retire
+- a force-with-lease push would overwrite remote work that was not just produced by the current workflow
 
 ## Standard flow
 
@@ -61,6 +63,18 @@ Stop and discuss with the user before continuing if any of these occur:
     gh pr checks
     ```
 
+    To wait for checks, prefer:
+
+    ```bash
+    gh pr checks <pr-number> --watch --fail-fast
+    ```
+
+    Older GitHub CLI versions may not support `gh pr checks --watch`. If that fails with an unknown flag, use the Actions run id from the check URLs and watch the run directly:
+
+    ```bash
+    gh run watch <run-id> --exit-status
+    ```
+
     If checks fail and the fix is obvious and within the current task scope, fix it on the feature branch, commit, push, and re-check. If the failure is ambiguous or broad, stop and discuss with the user.
 
 6. Squash merge the PR into `main` and delete the remote feature branch:
@@ -94,6 +108,26 @@ Stop and discuss with the user before continuing if any of these occur:
     ```
 
 10. Report the PR number, merge result, final local branch, and whether the worktree is clean.
+
+## Multiple dependent branches
+
+When the user asks to finish multiple branches as separate PRs, check whether later branches include earlier branch commits:
+
+```bash
+git log --oneline --decorate --graph main..<branch>
+```
+
+If branch B is stacked on branch A, finish branch A first. After branch A is squash-merged into `main`, update local `main`, then rebase branch B onto the new `main` so the second PR does not re-include branch A's commits:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch <branch-b>
+git rebase --onto main <branch-a-tip-before-merge> <branch-b>
+git push --force-with-lease origin <branch-b>
+```
+
+Use this only when the dependency is clear. If the old base tip is uncertain, inspect the graph first and stop if the branch relationship is ambiguous.
 
 ## Conflict handling
 

--- a/AGENTS/AGENTS_pr_workflow.md
+++ b/AGENTS/AGENTS_pr_workflow.md
@@ -8,6 +8,7 @@ Use this workflow when the user asks to create a pull request, merge a feature b
 - Default to the current branch when the user says to use the current branch.
 - If the user names a branch, use that branch.
 - Never create or merge a pull request from `main`.
+- `main` is protected by the `protect_main` repository ruleset. It requires a pull request, squash-only merge, strict required status checks, and deletion/non-fast-forward protection.
 - Never force-push, rewrite shared history, bypass branch protection, or use admin merge flags unless the user explicitly asks for that.
 - `git push --force-with-lease` is allowed only when an intentional rebase of the feature branch was required to keep the PR clean, such as after an earlier dependent branch was squash-merged.
 
@@ -51,22 +52,22 @@ Stop and discuss with the user before continuing if any of these occur:
 4. Create the pull request against `main`:
 
     ```bash
-    gh pr create --base main --head <feature-branch> --fill
+    gh pr create --base main --head <feature-branch> --title "<clear PR title>" --body-file -
     ```
 
-    If `--fill` produces an unsuitable title or body, use a concise semantic title and a short body that summarizes the user-visible change and verification.
+    Use a concise PR title and a short body that summarizes the user-visible change and verification. Avoid relying on `--fill` for broad or multi-commit branches unless the generated title and body are already clear.
 
 5. Inspect the PR:
 
     ```bash
     gh pr view
-    gh pr checks
+    gh pr checks --required
     ```
 
     To wait for checks, prefer:
 
     ```bash
-    gh pr checks <pr-number> --watch --fail-fast
+    gh pr checks <pr-number> --required --watch --fail-fast
     ```
 
     Older GitHub CLI versions may not support `gh pr checks --watch`. If that fails with an unknown flag, use the Actions run id from the check URLs and watch the run directly:
@@ -80,8 +81,10 @@ Stop and discuss with the user before continuing if any of these occur:
 6. Squash merge the PR into `main` and delete the remote feature branch:
 
     ```bash
-    gh pr merge --squash --delete-branch
+    gh pr merge <pr-number> --squash --delete-branch --subject "<type>(<scope>): <subject>"
     ```
+
+    The PR title can be human-readable, but the squash commit subject must follow this repo's Commitizen schema from `cz.yaml`, for example `feat(actions): add structured action declarations` or `docs(agents): refine pr workflow`. Do not rely on GitHub's default squash subject if the PR title is not already a valid semantic commit subject.
 
 7. Return local checkout to a clean, current `main`:
 

--- a/docs/mkdocs/reference/dockerised_dev.md
+++ b/docs/mkdocs/reference/dockerised_dev.md
@@ -175,6 +175,14 @@ git add -A
 cz commit  # Interactive conventional commit
 ```
 
+`main` is protected. Land changes through a pull request, wait for the required pytest matrix and Playwright smoke checks, then squash merge. The squash commit subject should follow the same Commitizen pattern, for example:
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch --subject "feat(scope): describe the change"
+```
+
+For agent-driven branch finish work, see `AGENTS/AGENTS_pr_workflow.md` in the repository root.
+
 ### 8. **Shutdown**
 
 ```bash


### PR DESCRIPTION
## Summary

- document that main is now protected by the protect_main ruleset
- update the agent PR workflow for required checks, semantic squash subjects, and stacked branch handling
- add the protected-main PR workflow to the Dockerised development git workflow section

## Verification

- git diff --check
