### PR TITLE
Fix PowerButton selection defaults

### DIFF
--- a/src/powercrud/actions.py
+++ b/src/powercrud/actions.py
@@ -155,24 +155,33 @@ class PowerButton:
 
     def to_dict(self) -> dict[str, Any]:
         """Return the primitive ``extra_buttons`` dictionary for this button."""
-        return _copy_without_none(
-            {
-                "url_name": self.url_name,
-                "text": self.text,
-                "needs_pk": self.needs_pk,
-                "button_class": self.button_class,
-                "htmx_target": self.htmx_target,
-                "display_modal": self.display_modal,
-                "modal_box_classes": self.modal_box_classes,
-                "refresh_list_on_modal_close": self.refresh_list_on_modal_close,
-                "extra_attrs": self.extra_attrs,
-                "extra_class_attrs": self.extra_class_attrs,
-                "uses_selection": self.uses_selection,
-                "selection_min_count": self.selection_min_count,
-                "selection_min_behavior": self.selection_min_behavior,
-                "selection_min_reason": self.selection_min_reason,
-            }
+        values: dict[str, Any] = {
+            "url_name": self.url_name,
+            "text": self.text,
+            "needs_pk": self.needs_pk,
+            "button_class": self.button_class,
+            "htmx_target": self.htmx_target,
+            "display_modal": self.display_modal,
+            "modal_box_classes": self.modal_box_classes,
+            "refresh_list_on_modal_close": self.refresh_list_on_modal_close,
+            "extra_attrs": self.extra_attrs,
+            "extra_class_attrs": self.extra_class_attrs,
+            "uses_selection": self.uses_selection,
+        }
+        has_selection_options = (
+            self.selection_min_count != 0
+            or self.selection_min_behavior != "allow"
+            or self.selection_min_reason is not None
         )
+        if self.uses_selection or has_selection_options:
+            values.update(
+                {
+                    "selection_min_count": self.selection_min_count,
+                    "selection_min_behavior": self.selection_min_behavior,
+                    "selection_min_reason": self.selection_min_reason,
+                }
+            )
+        return _copy_without_none(values)
 
 
 __all__ = ["PowerAction", "PowerButton"]

--- a/src/tests/test_core_phase1.py
+++ b/src/tests/test_core_phase1.py
@@ -692,6 +692,33 @@ def test_core_mixin_warns_when_selection_thresholds_without_uses_selection(caplo
 
 
 @pytest.mark.django_db
+def test_core_mixin_does_not_warn_for_plain_powerbutton_defaults(caplog):
+    class ButtonView(CoreMixin):
+        model = Book
+        fields = "__all__"
+        base_template_path = "sample/base.html"
+        extra_buttons = [
+            PowerButton(
+                text="Approvals Queue",
+                url_name="sample:bigbook-list",
+                button_class="btn-outline",
+                display_modal=False,
+                htmx_target="content",
+            )
+        ]
+
+    with caplog.at_level("WARNING", logger="powercrud"):
+        view = ButtonView()
+
+    assert view.extra_buttons[0]["uses_selection"] is False, (
+        "Plain PowerButton toolbar buttons should remain non-selection buttons."
+    )
+    assert "selection_min_* settings without uses_selection=True" not in caplog.text, (
+        "Generated PowerButton defaults should not trigger the explicit-threshold warning."
+    )
+
+
+@pytest.mark.django_db
 def test_core_mixin_normalizes_extra_button_modal_close_refresh_flag():
     class ButtonRefreshView(CoreMixin):
         model = Book

--- a/src/tests/test_poweractions.py
+++ b/src/tests/test_poweractions.py
@@ -91,6 +91,31 @@ def test_powerbutton_to_dict_exposes_primitive_extra_button_config():
     }, "PowerButton should compile to the primitive extra_buttons dictionary shape."
 
 
+def test_powerbutton_to_dict_omits_non_selection_default_thresholds():
+    button = PowerButton(
+        text="Approvals Queue",
+        url_name="sample:book-list",
+        button_class="btn-outline",
+        display_modal=False,
+        htmx_target="content",
+    )
+
+    button_dict = button.to_dict()
+
+    assert button_dict["uses_selection"] is False, (
+        "Plain PowerButton declarations should still expose the normalized selection flag."
+    )
+    assert "selection_min_count" not in button_dict, (
+        "Plain PowerButton declarations should not serialize generated selection defaults."
+    )
+    assert "selection_min_behavior" not in button_dict, (
+        "Plain PowerButton declarations should not look like threshold-configured buttons."
+    )
+    assert "selection_min_reason" not in button_dict, (
+        "Plain PowerButton declarations should omit empty threshold reason metadata."
+    )
+
+
 def test_powerbutton_with_options_returns_changed_copy_without_mutating_original():
     original = PowerButton(
         text="Home",


### PR DESCRIPTION
## Summary
- stop plain non-selection `PowerButton` declarations from serializing generated `selection_min_*` defaults
- keep selection-aware buttons and explicit primitive threshold warnings working as before
- add regression coverage for the declaration output and view-config warning path

## Verification
- `./runproj exec "./runtests --pytest src/tests/test_poweractions.py src/tests/test_core_phase1.py"` -> 135 passed
- `./runproj exec "./runtests"` -> Python 660 passed; Playwright 51 passed
