### PR TITLE
feat(extra-actions): add hidden_if row action hook

### DIFF
--- a/docs/mkdocs/guides/advanced/recipes.md
+++ b/docs/mkdocs/guides/advanced/recipes.md
@@ -199,18 +199,13 @@ class InvoiceCRUDView(PowerCRUDMixin, CRUDView):
             "button_class": "btn-accent",
             "display_modal": True,
             "needs_pk": True,
-            "disabled_if": "is_send_reminder_disabled",
-            "disabled_reason": "get_send_reminder_disabled_reason",
+            "disabled_state": "get_send_reminder_disabled_state",
         },
     ]
 
-    def is_send_reminder_disabled(self, obj, request) -> bool:
-        """Return whether reminder sending should be disabled for this invoice."""
-        return obj.status != "overdue"
-
-    def get_send_reminder_disabled_reason(self, obj, request) -> str | None:
+    def get_send_reminder_disabled_state(self, obj, request) -> str | None:
         """Return the tooltip reason when reminder sending is disabled."""
-        if self.is_send_reminder_disabled(obj, request):
+        if obj.status != "overdue":
             return "Reminders can only be sent for overdue invoices."
         return None
 ```

--- a/docs/mkdocs/guides/setup_core_crud.md
+++ b/docs/mkdocs/guides/setup_core_crud.md
@@ -181,10 +181,14 @@ class AuthorCRUDView(PowerCRUDMixin, CRUDView):
             "text": "View Again",
             "needs_pk": True,
             "display_modal": True,
+            "hidden_if": "should_hide_view_again",
             "disabled_state": "get_view_again_disabled_state",
             "modal_box_classes": "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
         },
     ]
+
+    def should_hide_view_again(self, obj, request):
+        return not obj.bio
 
     def get_view_again_disabled_state(self, obj, request):
         if obj.birth_date is None:
@@ -208,11 +212,14 @@ class AuthorCRUDView(PowerCRUDMixin, CRUDView):
     | `htmx_target` | `str` | HTMX target element used for non-modal actions when you need a custom swap target. |
     | `hx_post` | `bool` | If `True`, renders the action as an HTMX POST instead of the default GET. |
     | `lock_sensitive` | `bool` | Reuses PowerCRUD's existing blocked-row/lock logic so the action disables automatically when the row is not currently actionable. |
+    | `hidden_if` | `str` | Name of a view method with signature `(obj, request) -> bool` that decides whether this row action should be omitted. |
     | `disabled_state` | `str` | Name of a view method with signature `(obj, request) -> str | None | bool`. Return a non-empty string to disable the action and show the reason; return `None`, `False`, or an empty string to keep it enabled. |
-    | `disabled_if` | `str` | Name of a view method with signature `(obj, request) -> bool` that decides whether this row action should be disabled. |
-    | `disabled_reason` | `str` | Name of a view method with signature `(obj, request) -> str | None` that returns the tooltip/help text when the action is disabled. |
+    | `disabled_if` | `str` | Deprecated. Name of a view method with signature `(obj, request) -> bool` that decides whether this row action should be disabled. Use `disabled_state` instead. |
+    | `disabled_reason` | `str` | Deprecated. Name of a view method with signature `(obj, request) -> str | None` that returns the tooltip/help text when the action is disabled. Use `disabled_state` instead. |
 
     Do not combine `disabled_state` with `disabled_if` or `disabled_reason` on the same action.
+
+    Use `hidden_if` when an action is not applicable for a row. Use `disabled_state` when the action is applicable but unavailable and needs an explanatory reason. The legacy `disabled_if` / `disabled_reason` pair is deprecated and targeted for removal in v1.0.
 
 ??? note "Refreshing the list after custom modal close"
 

--- a/docs/mkdocs/guides/structured_api/poweractions.md
+++ b/docs/mkdocs/guides/structured_api/poweractions.md
@@ -204,7 +204,7 @@ def get_preview_disabled_state(self, obj, request):
 
 Return a non-empty string to disable the action and show that string as the reason. Return `None`, `False`, or an empty string to keep the action enabled.
 
-The older `disabled_if` and `disabled_reason` pair still works. Do not combine those legacy hooks with `disabled_state` on one action.
+The older `disabled_if` and `disabled_reason` pair still works for compatibility, but it is deprecated and targeted for removal in v1.0. Do not combine those legacy hooks with `disabled_state` on one action.
 
 Use `hidden_if` when the row action is not applicable and should not render. Use `disabled_state` when the action is applicable but unavailable and the user benefits from a reason.
 

--- a/docs/mkdocs/guides/structured_api/poweractions.md
+++ b/docs/mkdocs/guides/structured_api/poweractions.md
@@ -26,6 +26,7 @@ Use `PowerAction` or `PowerButton` when you want to name and reuse a pattern:
                 "needs_pk": True,
                 "display_modal": True,
                 "modal_box_classes": "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
+                "hidden_if": "should_hide_workflow_action",
                 "disabled_state": "get_workflow_action_disabled_state",
             },
             {
@@ -46,6 +47,7 @@ Use `PowerAction` or `PowerButton` when you want to name and reuse a pattern:
             url_name="cases:workflow-action",
             display_modal=True,
             modal_box_classes="modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
+            hidden_if="should_hide_workflow_action",
             disabled_state="get_workflow_action_disabled_state",
         )
 
@@ -72,6 +74,7 @@ ROW_PREVIEW = PowerAction(
     text="Description Preview",
     url_name="sample:book-description-preview",
     display_modal=True,
+    hidden_if="should_hide_description_preview",
     disabled_state="get_description_preview_disabled_state",
 )
 
@@ -83,6 +86,9 @@ extra_actions = [
         disabled_state=None,
     ),
 ]
+
+def should_hide_description_preview(self, obj, request):
+    return obj.archived
 
 def get_description_preview_disabled_state(self, obj, request):
     if not obj.description:
@@ -199,6 +205,8 @@ def get_preview_disabled_state(self, obj, request):
 Return a non-empty string to disable the action and show that string as the reason. Return `None`, `False`, or an empty string to keep the action enabled.
 
 The older `disabled_if` and `disabled_reason` pair still works. Do not combine those legacy hooks with `disabled_state` on one action.
+
+Use `hidden_if` when the row action is not applicable and should not render. Use `disabled_state` when the action is applicable but unavailable and the user benefits from a reason.
 
 ## Reference
 

--- a/docs/mkdocs/reference/complete_example.md
+++ b/docs/mkdocs/reference/complete_example.md
@@ -308,7 +308,7 @@ class ProjectCRUDView(PowerCRUDMixin, CRUDView):
 - `modal_box_classes` on a modal `extra_buttons` item replaces the view-level modal box classes only while that button's modal is open. Keep `flex max-h-[calc(100dvh-2rem)] flex-col` in the string if you want the supplied viewport-bounded behavior plus a custom width.
 - `modal_box_classes` also works on list-cell links and hook-returned list-cell links when `open_in = "modal"`.
 - `hidden_if` lets row `extra_actions` omit themselves entirely when an action is not applicable to that row.
-- `disabled_state` lets row `extra_actions` disable themselves through one hook that returns a disabled reason string, while `disabled_if` / `disabled_reason` remain available as the legacy paired hook style.
+- `disabled_state` lets row `extra_actions` disable themselves through one hook that returns a disabled reason string. The legacy `disabled_if` / `disabled_reason` pair remains available for compatibility but is deprecated.
 - `modal_box_classes` works the same way on modal `extra_actions`, including actions rendered inside the dropdown `More` menu.
 - `inline_edit_fields` is the current inline-editing configuration. Older `inline_edit_enabled` usage is legacy and should not be used in new code.
 - `inline_edit_always_visible = True` is the current default, so editable cells keep a subtle resting hint unless you disable it.

--- a/docs/mkdocs/reference/complete_example.md
+++ b/docs/mkdocs/reference/complete_example.md
@@ -237,17 +237,17 @@ class ProjectCRUDView(PowerCRUDMixin, CRUDView):
             "needs_pk": True,
             "button_class": "btn-secondary",
             "display_modal": True,
-            "disabled_if": "is_history_action_disabled",
-            "disabled_reason": "get_history_action_disabled_reason",
+            "hidden_if": "should_hide_history_action",
+            "disabled_state": "get_history_action_disabled_state",
             "refresh_list_on_modal_close": True,
             "modal_box_classes": "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
         },
     ]
 
-    def is_history_action_disabled(self, obj, request):
-        return obj.archived_at is None
+    def should_hide_history_action(self, obj, request):
+        return obj.status == "draft"
 
-    def get_history_action_disabled_reason(self, obj, request):
+    def get_history_action_disabled_state(self, obj, request):
         if obj.archived_at is None:
             return "History is only available for archived projects."
         return None
@@ -307,6 +307,7 @@ class ProjectCRUDView(PowerCRUDMixin, CRUDView):
 - `selection_min_behavior = "disable"` lets the frontend grey out a selection-aware header button until enough rows are selected, but the endpoint should still validate the selection server-side.
 - `modal_box_classes` on a modal `extra_buttons` item replaces the view-level modal box classes only while that button's modal is open. Keep `flex max-h-[calc(100dvh-2rem)] flex-col` in the string if you want the supplied viewport-bounded behavior plus a custom width.
 - `modal_box_classes` also works on list-cell links and hook-returned list-cell links when `open_in = "modal"`.
+- `hidden_if` lets row `extra_actions` omit themselves entirely when an action is not applicable to that row.
 - `disabled_state` lets row `extra_actions` disable themselves through one hook that returns a disabled reason string, while `disabled_if` / `disabled_reason` remain available as the legacy paired hook style.
 - `modal_box_classes` works the same way on modal `extra_actions`, including actions rendered inside the dropdown `More` menu.
 - `inline_edit_fields` is the current inline-editing configuration. Older `inline_edit_enabled` usage is legacy and should not be used in new code.

--- a/docs/mkdocs/reference/config_options.md
+++ b/docs/mkdocs/reference/config_options.md
@@ -36,7 +36,7 @@ For the mental model behind the option groups, see [PowerCRUD Concepts](../guide
 | `detail_properties_exclude` (`list[str]`) | `list[str]` | `[]` | All listed detail properties render | Remove specific properties from the detail page. | [Setup & Core CRUD basics](../guides/setup_core_crud.md) |
 | `dropdown_sort_options` (`dict`) | `dict[str, str]` | `{}` | PowerCRUD orders dropdowns by `name/title/...` heuristics | Explicit ordering for dropdowns in filters, forms, and bulk edit widgets. | [Bulk editing (synchronous)](../guides/bulk_edit_sync.md) |
 | `exclude` (`list[str]`) | `list[str]` | `[]` | Every concrete model field is shown | Remove individual fields from the list view while keeping the rest. | [Setup & Core CRUD basics](../guides/setup_core_crud.md) |
-| `extra_actions` (`list[dict \| PowerAction]`) | `list[action spec]` | `[]` | Only the default action buttons render | Define extra per-row actions (URL, label, attributes). Modal actions may set per-trigger `modal_box_classes` for custom width/height and `refresh_list_on_modal_close` for close-driven list refreshes. | [Complete Example](complete_example.md) |
+| `extra_actions` (`list[dict \| PowerAction]`) | `list[action spec]` | `[]` | Only the default action buttons render | Define extra per-row actions (URL, label, attributes). Modal actions may set per-trigger `modal_box_classes`, `refresh_list_on_modal_close`, `hidden_if`, and disabled-state hooks. | [Complete Example](complete_example.md) |
 | `extra_actions_mode` (`str`) | `'buttons'`, `'dropdown'` | `'buttons'` | Extra row actions render as visible buttons after the standard actions | Control how row-level `extra_actions` are rendered. Use `'dropdown'` to keep `View/Edit/Delete` visible and move only the extra row actions into a `More` overflow menu. | [Setup & Core CRUD basics](../guides/setup_core_crud.md) |
 | `extra_actions_dropdown_open_upward_bottom_rows` (`int`) | `int >= 0` | `3` | All `More` menus open downward | In dropdown mode, open the `More` menu upward for the last N rendered rows on the current page. Set `0` to disable this behavior. | [Setup & Core CRUD basics](../guides/setup_core_crud.md) |
 | `extra_button_classes` (`str`) | `str` | `""` | Extra buttons use the default button styling | Additional CSS classes shared by every entry in `extra_buttons`. | [Styling & Tailwind](../guides/styling_tailwind.md) |
@@ -387,8 +387,8 @@ extra_actions = [
         "text": "View Again",
         "needs_pk": True,
         "display_modal": True,
-        "disabled_if": "is_view_again_disabled",
-        "disabled_reason": "get_view_again_disabled_reason",
+        "hidden_if": "should_hide_view_again",
+        "disabled_state": "get_view_again_disabled_state",
         "refresh_list_on_modal_close": True,
         "modal_box_classes": "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
     },
@@ -404,9 +404,11 @@ Notes:
 - Set `extra_actions_dropdown_open_upward_bottom_rows = 0` to keep every dropdown opening downward.
 - `modal_box_classes` is only used when `display_modal=True`; it replaces the view-level `modal_box_classes` while this row action's modal is open.
 - `refresh_list_on_modal_close` is only used when `display_modal=True`; prefer `HX-Trigger: {"refreshTable": true}` when the endpoint knows it changed data.
+- `hidden_if` is an optional view method name with signature `(obj, request) -> bool`. Return `True` to omit the action for that row. Hidden actions are removed before disabled hooks are evaluated.
 - `disabled_state` is a single-hook alternative to `disabled_if` / `disabled_reason`. Return a non-empty string to disable the action and show that string as the reason; return `None`, `False`, or an empty string to keep it enabled.
 - `disabled_if` and `disabled_reason` are optional view method names used to disable a row action based on the current object and request.
 - Do not combine `disabled_state` with `disabled_if` or `disabled_reason` on the same action.
+- Use `hidden_if` when an action is not applicable for a row. Use `disabled_state` when the action is applicable but unavailable and needs an explanatory reason.
 - `lock_sensitive` remains available when an action should also disable under PowerCRUD's existing lock/blocked-row state.
 
 ??? info "Parameter Guide"
@@ -423,6 +425,7 @@ Notes:
     | `htmx_target` | `str` | HTMX target element to update for non-modal or custom-target flows. |
     | `hx_post` | `bool` | Sends the action as an HTMX POST instead of the default GET when `True`. |
     | `lock_sensitive` | `bool` | Disables the action automatically when PowerCRUD marks the row as blocked by its existing lock logic. |
+    | `hidden_if` | `str` | Name of a view method with signature `(obj, request) -> bool` that decides whether the action should be omitted for that row. |
     | `disabled_state` | `str` | Name of a view method with signature `(obj, request) -> str | None | bool` that returns a disabled reason string, or a falsey enabled value. |
     | `disabled_if` | `str` | Name of a view method with signature `(obj, request) -> bool` that decides whether the action is disabled for that row. |
     | `disabled_reason` | `str` | Name of a view method with signature `(obj, request) -> str | None` that returns the disabled tooltip/help text. |

--- a/docs/mkdocs/reference/config_options.md
+++ b/docs/mkdocs/reference/config_options.md
@@ -406,7 +406,7 @@ Notes:
 - `refresh_list_on_modal_close` is only used when `display_modal=True`; prefer `HX-Trigger: {"refreshTable": true}` when the endpoint knows it changed data.
 - `hidden_if` is an optional view method name with signature `(obj, request) -> bool`. Return `True` to omit the action for that row. Hidden actions are removed before disabled hooks are evaluated.
 - `disabled_state` is a single-hook alternative to `disabled_if` / `disabled_reason`. Return a non-empty string to disable the action and show that string as the reason; return `None`, `False`, or an empty string to keep it enabled.
-- `disabled_if` and `disabled_reason` are optional view method names used to disable a row action based on the current object and request.
+- `disabled_if` and `disabled_reason` are deprecated view method names used to disable a row action based on the current object and request. Use `disabled_state` instead.
 - Do not combine `disabled_state` with `disabled_if` or `disabled_reason` on the same action.
 - Use `hidden_if` when an action is not applicable for a row. Use `disabled_state` when the action is applicable but unavailable and needs an explanatory reason.
 - `lock_sensitive` remains available when an action should also disable under PowerCRUD's existing lock/blocked-row state.
@@ -427,8 +427,8 @@ Notes:
     | `lock_sensitive` | `bool` | Disables the action automatically when PowerCRUD marks the row as blocked by its existing lock logic. |
     | `hidden_if` | `str` | Name of a view method with signature `(obj, request) -> bool` that decides whether the action should be omitted for that row. |
     | `disabled_state` | `str` | Name of a view method with signature `(obj, request) -> str | None | bool` that returns a disabled reason string, or a falsey enabled value. |
-    | `disabled_if` | `str` | Name of a view method with signature `(obj, request) -> bool` that decides whether the action is disabled for that row. |
-    | `disabled_reason` | `str` | Name of a view method with signature `(obj, request) -> str | None` that returns the disabled tooltip/help text. |
+    | `disabled_if` | `str` | Deprecated. Name of a view method with signature `(obj, request) -> bool` that decides whether the action is disabled for that row. Use `disabled_state` instead. |
+    | `disabled_reason` | `str` | Deprecated. Name of a view method with signature `(obj, request) -> str | None` that returns the disabled tooltip/help text. Use `disabled_state` instead. |
 
 ### Searchable select enhancement
 

--- a/docs/mkdocs/reference/deprecations.md
+++ b/docs/mkdocs/reference/deprecations.md
@@ -2,6 +2,42 @@
 
 This page tracks public APIs that still work for compatibility but are no longer the preferred path.
 
+## Legacy Extra-Action Disabled Hooks
+
+!!! warning "Deprecated: `disabled_if` and `disabled_reason` on `extra_actions`"
+
+    The paired `disabled_if` / `disabled_reason` row-action hooks are deprecated and targeted for removal in v1.0.
+
+    ```python
+    extra_actions = [
+        {
+            "url_name": "cases:case-preview",
+            "text": "Preview",
+            "disabled_if": "is_preview_disabled",
+            "disabled_reason": "get_preview_disabled_reason",
+        },
+    ]
+    ```
+
+Use `disabled_state` instead. It keeps the enabled/disabled decision and reason text in one hook:
+
+```python
+extra_actions = [
+    {
+        "url_name": "cases:case-preview",
+        "text": "Preview",
+        "disabled_state": "get_preview_disabled_state",
+    },
+]
+
+def get_preview_disabled_state(self, obj, request):
+    if not obj.ready_for_preview:
+        return "Preview is available after the case is ready."
+    return None
+```
+
+Use `hidden_if` separately when the action is not applicable and should not render for a row.
+
 ## Legacy List-Cell Tooltip Hook
 
 !!! warning "Deprecated: `list_cell_tooltip_fields` as a list"

--- a/docs/mkdocs/reference/poweractions.md
+++ b/docs/mkdocs/reference/poweractions.md
@@ -25,6 +25,7 @@ PowerAction(
     hx_post=False,
     lock_sensitive=False,
     refresh_list_on_modal_close=False,
+    hidden_if=None,
     disabled_state=None,
     disabled_if=None,
     disabled_reason=None,
@@ -43,6 +44,7 @@ PowerAction(
 | `hx_post` | `False` | Render the action as an HTMX POST. |
 | `lock_sensitive` | `False` | Disable the action under PowerCRUD row-lock logic. |
 | `refresh_list_on_modal_close` | `False` | Refresh the list when this modal closes. |
+| `hidden_if` | `None` | Boolean hook name that hides this row action when true. |
 | `disabled_state` | `None` | Single disabled-state hook name. |
 | `disabled_if` | `None` | Legacy disabled boolean hook name. |
 | `disabled_reason` | `None` | Legacy disabled reason hook name. |
@@ -57,6 +59,7 @@ ROW_MODAL = PowerAction(
     url_name="cases:workflow-action",
     display_modal=True,
     modal_box_classes="modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
+    hidden_if="should_hide_workflow_action",
     disabled_state="get_workflow_action_disabled_state",
 )
 
@@ -144,6 +147,7 @@ extra_buttons = [
 
 - `text` and `url_name` must be non-empty strings.
 - Boolean parameters must be `True`, `False`, or `None` where the constructor explicitly allows `None`.
+- `PowerAction.hidden_if` must be a method-name string when set.
 - `PowerAction.disabled_state` cannot be combined with `disabled_if` or `disabled_reason`.
 - `PowerAction.disabled_reason` requires `disabled_if`; use `disabled_state` for the single-hook contract.
 - `PowerButton.selection_min_behavior` must be `"allow"` or `"disable"`.

--- a/docs/mkdocs/reference/poweractions.md
+++ b/docs/mkdocs/reference/poweractions.md
@@ -46,8 +46,8 @@ PowerAction(
 | `refresh_list_on_modal_close` | `False` | Refresh the list when this modal closes. |
 | `hidden_if` | `None` | Boolean hook name that hides this row action when true. |
 | `disabled_state` | `None` | Single disabled-state hook name. |
-| `disabled_if` | `None` | Legacy disabled boolean hook name. |
-| `disabled_reason` | `None` | Legacy disabled reason hook name. |
+| `disabled_if` | `None` | Deprecated legacy disabled boolean hook name. Use `disabled_state` instead. |
+| `disabled_reason` | `None` | Deprecated legacy disabled reason hook name. Use `disabled_state` instead. |
 
 `to_dict()` returns the base `extra_actions` dictionary. `with_options(...)` returns a new `PowerAction` with selected values changed.
 
@@ -149,6 +149,7 @@ extra_buttons = [
 - Boolean parameters must be `True`, `False`, or `None` where the constructor explicitly allows `None`.
 - `PowerAction.hidden_if` must be a method-name string when set.
 - `PowerAction.disabled_state` cannot be combined with `disabled_if` or `disabled_reason`.
+- `PowerAction.disabled_if` and `PowerAction.disabled_reason` are deprecated and targeted for removal in v1.0.
 - `PowerAction.disabled_reason` requires `disabled_if`; use `disabled_state` for the single-hook contract.
 - `PowerButton.selection_min_behavior` must be `"allow"` or `"disable"`.
 - `PowerButton` cannot combine `uses_selection=True` with `needs_pk=True`.

--- a/docs/mkdocs/reference/sample_app.md
+++ b/docs/mkdocs/reference/sample_app.md
@@ -312,6 +312,7 @@ class PowerFieldBookCRUDView(PowerCRUDAsyncMixin, CRUDView):
         row_modal.with_options(
             text="Description Preview",
             url_name="sample:bigbook-description-preview",
+            hidden_if="should_hide_description_preview",
             disabled_state="get_description_preview_disabled_state",
         ),
     ]
@@ -500,13 +501,14 @@ extra_actions = [
         "text": "Description Preview",
         "needs_pk": True,
         "display_modal": True,
+        "hidden_if": "should_hide_description_preview",
         "disabled_state": "get_description_preview_disabled_state",
         "modal_box_classes": "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
     },
 ]
 ```
 
-That lets the sample app demonstrate selection-aware header actions, conditionally disabled row actions, and per-trigger modal sizing in the same CRUD surface. `disabled_state` is the single-hook disabled contract: return a non-empty string to disable the action and show that string as the reason. `Selected Summary` intentionally uses the view default modal width, while `Home in Modal!` shows a header-button override. The `modal_box_classes` entries are full replacement strings: they keep the default viewport-height classes and add per-trigger width classes for those specific modal calls.
+That lets the sample app demonstrate selection-aware header actions, hidden row actions, conditionally disabled row actions, and per-trigger modal sizing in the same CRUD surface. `hidden_if` omits a row action when it is not applicable. `disabled_state` is the single-hook disabled contract: return a non-empty string to disable the action and show that string as the reason. `Selected Summary` intentionally uses the view default modal width, while `Home in Modal!` shows a header-button override. The `modal_box_classes` entries are full replacement strings: they keep the default viewport-height classes and add per-trigger width classes for those specific modal calls.
 
 ## Management Commands
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,6 @@ extra_css:
 extra_javascript:
   # mathjax
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   # tablesort
   - https://unpkg.com/tablesort@5.6.0/dist/tablesort.min.js

--- a/src/powercrud/actions.py
+++ b/src/powercrud/actions.py
@@ -45,6 +45,7 @@ class PowerAction:
     hx_post: bool = False
     lock_sensitive: bool = False
     refresh_list_on_modal_close: bool = False
+    hidden_if: str | None = None
     disabled_state: str | None = None
     disabled_if: str | None = None
     disabled_reason: str | None = None
@@ -62,7 +63,12 @@ class PowerAction:
             "refresh_list_on_modal_close",
         ):
             _validate_bool(getattr(self, field_name), field_name, class_name)
-        for field_name in ("disabled_state", "disabled_if", "disabled_reason"):
+        for field_name in (
+            "hidden_if",
+            "disabled_state",
+            "disabled_if",
+            "disabled_reason",
+        ):
             _validate_optional_method_name(
                 getattr(self, field_name),
                 field_name,
@@ -95,6 +101,7 @@ class PowerAction:
                 "hx_post": self.hx_post,
                 "lock_sensitive": self.lock_sensitive,
                 "refresh_list_on_modal_close": self.refresh_list_on_modal_close,
+                "hidden_if": self.hidden_if,
                 "disabled_state": self.disabled_state,
                 "disabled_if": self.disabled_if,
                 "disabled_reason": self.disabled_reason,

--- a/src/powercrud/mixins/config_mixin.py
+++ b/src/powercrud/mixins/config_mixin.py
@@ -1111,6 +1111,11 @@ class ConfigMixin:
                 )
 
             normalized = action.copy()
+            hidden_if = self._resolve_extra_action_method(
+                normalized.get("hidden_if"),
+                index,
+                "hidden_if",
+            )
             disabled_state = self._resolve_extra_action_method(
                 normalized.get("disabled_state"),
                 index,
@@ -1141,6 +1146,7 @@ class ConfigMixin:
                 )
                 disabled_reason = None
 
+            normalized["hidden_if"] = hidden_if
             normalized["disabled_state"] = disabled_state
             normalized["disabled_if"] = disabled_if
             normalized["disabled_reason"] = disabled_reason

--- a/src/powercrud/templatetags/powercrud.py
+++ b/src/powercrud/templatetags/powercrud.py
@@ -254,6 +254,28 @@ def _resolve_extra_action_disabled_state(
     return disable, disabled_reason
 
 
+def _resolve_extra_action_hidden_state(
+    *,
+    view: Any,
+    object: Any,
+    action: Dict[str, Any],
+    request: Any,
+) -> bool:
+    """
+    Determine whether an extra action should be hidden for a row.
+    """
+    hidden_if_name = action.get("hidden_if")
+    if not hidden_if_name:
+        return False
+    hidden_if = _resolve_named_view_method(view, hidden_if_name)
+    if hidden_if is None:
+        return False
+    try:
+        return bool(hidden_if(object, request))
+    except Exception:
+        return False
+
+
 def _resolve_standard_action_disabled_state(
     *,
     view: Any,
@@ -810,6 +832,14 @@ def action_links(view: Any, object: Any) -> str:
         )
 
         if url is not None:
+            if _resolve_extra_action_hidden_state(
+                view=view,
+                object=object,
+                action=action,
+                request=getattr(view, "request", None),
+            ):
+                continue
+
             htmx_target: str = action.get("htmx_target", default_target)
             if htmx_target and not htmx_target.startswith("#"):
                 htmx_target = f"#{htmx_target}"

--- a/src/sample/views.py
+++ b/src/sample/views.py
@@ -262,19 +262,19 @@ class BookCRUDView(SampleCRUDMixin):
             "button_class": "btn-secondary",
             "htmx_target": "powercrudModalContent",
             "display_modal": True,
-            "disabled_if": "is_description_preview_disabled",
-            "disabled_reason": "get_description_preview_disabled_reason",
+            "hidden_if": "should_hide_description_preview",
+            "disabled_state": "get_description_preview_disabled_state",
             "modal_box_classes": "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 max-w-5xl flex-col",
         },
     ]
 
-    def is_description_preview_disabled(self, obj, request):
-        """Return True when the row lacks description content for preview."""
-        return not bool((obj.description or "").strip())
+    def should_hide_description_preview(self, obj, request):
+        """Return True when the preview action is not relevant for the row."""
+        return obj.title.startswith("Hidden Preview")
 
-    def get_description_preview_disabled_reason(self, obj, request):
-        """Return the tooltip shown when description preview is unavailable."""
-        if self.is_description_preview_disabled(obj, request):
+    def get_description_preview_disabled_state(self, obj, request):
+        """Return the disabled reason when preview should remain visible but unavailable."""
+        if not bool((obj.description or "").strip()):
             return "This book does not have a description yet."
         return None
 
@@ -615,6 +615,7 @@ class PowerFieldBookCRUDView(SampleCRUDMixin):
             button_class="btn-secondary",
             lock_sensitive=False,
             refresh_list_on_modal_close=False,
+            hidden_if="should_hide_description_preview",
             disabled_state="get_description_preview_disabled_state",
             modal_box_classes=(
                 "modal-box flex max-h-[calc(100dvh-2rem)] w-11/12 "
@@ -636,6 +637,10 @@ class PowerFieldBookCRUDView(SampleCRUDMixin):
         if obj.isbn_empty:
             return "This book does not currently have an ISBN."
         return f"ISBN: {obj.isbn}"
+
+    def should_hide_description_preview(self, obj, request):
+        """Return True when the preview action is not relevant for the row."""
+        return obj.title.startswith("Hidden Preview")
 
     def get_description_preview_disabled_state(self, obj, request):
         """Return the disabled reason for the helper-backed preview action."""

--- a/src/tests/test_core_phase1.py
+++ b/src/tests/test_core_phase1.py
@@ -836,6 +836,25 @@ def test_core_mixin_rejects_unknown_extra_action_disabled_state_hook():
 
 
 @pytest.mark.django_db
+def test_core_mixin_rejects_unknown_extra_action_hidden_hook():
+    """Reject primitive hidden_if declarations that reference no view method."""
+    class BrokenView(CoreMixin):
+        model = Book
+        fields = "__all__"
+        base_template_path = "sample/base.html"
+        extra_actions = [
+            {
+                "url_name": "sample:bigbook-description-preview",
+                "text": "Description Preview",
+                "hidden_if": "missing_hidden_hook",
+            }
+        ]
+
+    with pytest.raises(ImproperlyConfigured, match="hidden_if"):
+        BrokenView()
+
+
+@pytest.mark.django_db
 def test_core_mixin_rejects_mixed_extra_action_disabled_styles():
     class BrokenView(CoreMixin):
         model = Book
@@ -891,6 +910,40 @@ def test_core_mixin_accepts_extra_action_disabled_state_hook():
 
 
 @pytest.mark.django_db
+def test_core_mixin_accepts_extra_action_hidden_hook_with_disabled_state():
+    """Accept primitive hidden_if declarations alongside disabled_state hooks."""
+    class ActionView(CoreMixin):
+        model = Book
+        fields = "__all__"
+        base_template_path = "sample/base.html"
+        extra_actions = [
+            {
+                "url_name": "sample:bigbook-description-preview",
+                "text": "Description Preview",
+                "hidden_if": "should_hide_description_preview",
+                "disabled_state": "get_description_disabled_state",
+            }
+        ]
+
+        def should_hide_description_preview(self, obj, request):
+            """Return no hidden state for config validation."""
+            return False
+
+        def get_description_disabled_state(self, obj, request):
+            """Return no disabled state for config validation."""
+            return None
+
+    view = ActionView()
+
+    assert view.extra_actions[0]["hidden_if"] == "should_hide_description_preview", (
+        "Primitive extra_actions should accept a hidden_if hook alongside disabled_state."
+    )
+    assert view.extra_actions[0]["disabled_state"] == "get_description_disabled_state", (
+        "Primitive extra_actions should preserve the disabled_state hook when hidden_if is configured."
+    )
+
+
+@pytest.mark.django_db
 def test_core_mixin_accepts_poweraction_in_extra_actions():
     class ActionView(CoreMixin):
         model = Book
@@ -901,6 +954,7 @@ def test_core_mixin_accepts_poweraction_in_extra_actions():
                 text="Description Preview",
                 url_name="sample:bigbook-description-preview",
                 display_modal=True,
+                hidden_if="should_hide_description_preview",
                 disabled_state="get_description_disabled_state",
             ),
             {
@@ -913,8 +967,15 @@ def test_core_mixin_accepts_poweraction_in_extra_actions():
             """Return no disabled state for config validation."""
             return None
 
+        def should_hide_description_preview(self, obj, request):
+            """Return no hidden state for config validation."""
+            return False
+
     view = ActionView()
 
+    assert view.extra_actions[0]["hidden_if"] == "should_hide_description_preview", (
+        "PowerAction declarations should normalize hidden_if into primitive extra_actions dictionaries."
+    )
     assert view.extra_actions[0]["disabled_state"] == "get_description_disabled_state", (
         "PowerAction declarations should normalize into primitive extra_actions dictionaries."
     )
@@ -2850,6 +2911,62 @@ def test_book_list_renders_disabled_extra_action_with_reason(client):
         "w-11/12 max-w-5xl flex-col'"
     ) in response_text, (
         "Sample modal extra action should demonstrate per-action modal sizing."
+    )
+
+
+@pytest.mark.django_db
+def test_book_list_hides_primitive_extra_action_when_hidden_hook_matches(client):
+    """Hide primitive row actions from the base book sample when hidden_if matches."""
+    author = Author.objects.create(name="Primitive Hidden Action Author")
+    Book.objects.create(
+        title="Hidden Preview Primitive",
+        author=author,
+        published_date=date(2024, 10, 2),
+        bestseller=False,
+        isbn="9876543210668",
+        pages=41,
+        description="This row would otherwise have a preview.",
+    )
+
+    response = client.get(reverse("sample:bigbook-list"))
+    response_text = " ".join(response.content.decode().split())
+
+    assert response.status_code == 200, (
+        "Book list view should render successfully so primitive hidden_if behavior can be inspected."
+    )
+    assert "Description Preview" not in response_text, (
+        "Base BookCRUDView should hide the primitive description-preview action when hidden_if matches."
+    )
+    assert ">More<" in response_text, (
+        "The row should keep More visible because the Normal Edit extra action still applies."
+    )
+
+
+@pytest.mark.django_db
+def test_powerfield_book_list_hides_poweraction_when_hidden_hook_matches(client):
+    """Hide PowerAction row actions from the PowerField book sample when hidden_if matches."""
+    author = Author.objects.create(name="PowerAction Hidden Action Author")
+    Book.objects.create(
+        title="Hidden Preview PowerAction",
+        author=author,
+        published_date=date(2024, 10, 3),
+        bestseller=False,
+        isbn="9876543210669",
+        pages=42,
+        description="This row would otherwise have a preview.",
+    )
+
+    response = client.get(reverse("sample:powerfield-book-list"))
+    response_text = " ".join(response.content.decode().split())
+
+    assert response.status_code == 200, (
+        "PowerField book list view should render successfully so PowerAction hidden_if behavior can be inspected."
+    )
+    assert "Description Preview" not in response_text, (
+        "PowerFieldBookCRUDView should hide the PowerAction description-preview action when hidden_if matches."
+    )
+    assert ">More<" in response_text, (
+        "The row should keep More visible because the Normal Edit PowerAction still applies."
     )
 
 

--- a/src/tests/test_poweractions.py
+++ b/src/tests/test_poweractions.py
@@ -9,6 +9,7 @@ def test_poweraction_to_dict_exposes_primitive_extra_action_config():
         url_name="sample:book-detail",
         display_modal=True,
         button_class="btn-secondary",
+        hidden_if="should_hide_preview",
         disabled_state="get_preview_disabled_state",
     )
 
@@ -21,6 +22,7 @@ def test_poweraction_to_dict_exposes_primitive_extra_action_config():
         "hx_post": False,
         "lock_sensitive": False,
         "refresh_list_on_modal_close": False,
+        "hidden_if": "should_hide_preview",
         "disabled_state": "get_preview_disabled_state",
     }, "PowerAction should compile to the primitive extra_actions dictionary shape."
 
@@ -55,6 +57,16 @@ def test_poweraction_rejects_mixed_disabled_state_styles():
             url_name="sample:book-detail",
             disabled_state="get_preview_disabled_state",
             disabled_if="is_preview_disabled",
+        )
+
+
+def test_poweraction_rejects_invalid_hidden_if_method_name():
+    """Reject non-string PowerAction hidden_if declarations."""
+    with pytest.raises(ValueError, match="hidden_if"):
+        PowerAction(
+            text="Preview",
+            url_name="sample:book-detail",
+            hidden_if=True,
         )
 
 

--- a/src/tests/test_templatetags_powercrud.py
+++ b/src/tests/test_templatetags_powercrud.py
@@ -183,6 +183,10 @@ class TemplateViewStub:
             return "Preview requires a description."
         return None
 
+    def should_hide_preview(self, obj, request):
+        """Return True when the preview action should not render."""
+        return obj.title.startswith("Hidden Preview")
+
     def get_bulk_selection_key_suffix(self):
         return "user"
 
@@ -438,6 +442,36 @@ def test_action_links_leave_extra_action_enabled_when_disabled_state_is_empty():
 
 
 @pytest.mark.django_db
+def test_action_links_hide_extra_action_before_disabled_state():
+    """Hide row actions before disabled_state can render a disabled reason."""
+    author = Author.objects.create(name="Hidden Action")
+    book = Book.objects.create(
+        title="Hidden Preview Row",
+        author=author,
+        published_date=date(2024, 1, 6),
+        bestseller=False,
+        isbn="9876543210005",
+        pages=42,
+        description="",
+    )
+    request = apply_session(RequestFactory().get("/"))
+    view = TemplateViewStub(request)
+    view.extra_actions[0].pop("disabled_if")
+    view.extra_actions[0].pop("disabled_reason")
+    view.extra_actions[0]["hidden_if"] = "should_hide_preview"
+    view.extra_actions[0]["disabled_state"] = "get_preview_disabled_state"
+
+    html = powercrud.action_links(view, book)
+
+    assert "Preview" not in html, (
+        "hidden_if should remove the action instead of rendering it disabled."
+    )
+    assert "Preview requires a description." not in html, (
+        "PowerCRUD should not evaluate/render disabled_state details for hidden actions."
+    )
+
+
+@pytest.mark.django_db
 def test_action_links_can_render_extra_actions_in_dropdown():
     author = Author.objects.create(name="Dana")
     book = Book.objects.create(
@@ -475,6 +509,45 @@ def test_action_links_can_render_extra_actions_in_dropdown():
     assert (
         "?page=2" in html
     ), "Dropdown menu actions should continue to preserve modal query-string context."
+
+
+@pytest.mark.django_db
+def test_action_links_omit_dropdown_more_when_all_extra_actions_are_hidden():
+    """Omit the row More trigger when hidden_if removes every extra action."""
+    author = Author.objects.create(name="Hidden Dropdown")
+    book = Book.objects.create(
+        title="Hidden Preview Dropdown",
+        author=author,
+        published_date=date(2024, 2, 3),
+        bestseller=False,
+        isbn="9876543210124",
+        pages=77,
+        description="Dropdown preview",
+    )
+    request = apply_session(RequestFactory().get("/"))
+    view = TemplateViewStub(request)
+    view.extra_actions_mode = "dropdown"
+    view.extra_actions = [
+        {
+            "url_name": "sample:book-detail",
+            "text": "Preview",
+            "button_class": "btn-secondary",
+            "display_modal": True,
+            "hidden_if": "should_hide_preview",
+        }
+    ]
+
+    html = powercrud.action_links(view, book)
+
+    assert "Preview" not in html, (
+        "Dropdown row action mode should omit hidden extra actions from the menu template."
+    )
+    assert "data-powercrud-row-actions-trigger='true'" not in html, (
+        "Dropdown row action mode should not render More when every extra action is hidden."
+    )
+    assert "data-powercrud-row-actions-template='true'" not in html, (
+        "Dropdown row action mode should not render an empty floating menu template."
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Add `hidden_if` support for row-level `extra_actions` so non-applicable actions can be omitted per row.
- Add `PowerAction(hidden_if=...)` support and sample coverage for both primitive and PowerAction book views.
- Update docs for `hidden_if` and mark `disabled_if` / `disabled_reason` as deprecated for v1.0 removal.

## Verification

- `./runtests --pytest src/tests/test_poweractions.py src/tests/test_templatetags_powercrud.py::test_action_links_hide_extra_action_before_disabled_state src/tests/test_templatetags_powercrud.py::test_action_links_omit_dropdown_more_when_all_extra_actions_are_hidden src/tests/test_core_phase1.py::test_core_mixin_rejects_unknown_extra_action_hidden_hook src/tests/test_core_phase1.py::test_core_mixin_accepts_extra_action_hidden_hook_with_disabled_state src/tests/test_core_phase1.py::test_core_mixin_accepts_poweraction_in_extra_actions src/tests/test_core_phase1.py::test_book_list_renders_disabled_extra_action_with_reason src/tests/test_core_phase1.py::test_book_list_hides_primitive_extra_action_when_hidden_hook_matches src/tests/test_core_phase1.py::test_powerfield_book_list_hides_poweraction_when_hidden_hook_matches src/tests/test_core_phase1.py::test_book_list_renders_extra_actions_in_dropdown`
- `19 passed`