### PR TITLE
Release 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ During the `0.x` series, breaking changes can occur, although we try to minimise
 
 Version numbers below correspond to published git tags. The more important releases include a little extra narrative and upgrade context; smaller patch releases remain deliberately brief. For full detail between any two versions, use the GitHub compare view for the matching tags.
 
+## 0.7.7 (2026-06-10)
+- **Fix (favourites)**: mark selected favourite dirty from column chooser
+- **Fix (toolbar)**: make dropdown controls mutually exclusive
+
 ## 0.7.6 (2026-06-10)
 - **Fix (favourites)**: preserve column chooser and auto apply state
   

--- a/new_release.sh
+++ b/new_release.sh
@@ -673,9 +673,9 @@ function prepare_release_in_container {
     require_tag_absent "$new_version"
     base_head=$(git rev-parse HEAD)
 
+    update_project_version "$new_version"
     run_prepare_validation
 
-    update_project_version "$new_version"
     cz changelog --incremental --unreleased-version="$new_version"
 
     last_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-powercrud"
-version = "0.7.6"
+version = "0.7.7"
 description = "Advanced CRUD for perfectionists with deadlines. An opinionated Neapolitan extension, with sprinkles."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "django-powercrud"
-version = "0.7.5"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "django-htmx" },


### PR DESCRIPTION
## Summary

- Publish release 0.7.7 through the protected-main release workflow.
- Update version, lockfile, changelog, and built assets prepared by new_release.sh.

## Verification

- new_release.sh prepare validation completed.
- Required GitHub checks will run on this PR before merge.