### PR TITLE
chore(deps): harden renovate automerge policy

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -5,8 +5,12 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     uses: ./.github/workflows/run_tests.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,8 @@ jobs:
   test-matrix:
     needs: classify-tag
     uses: ./.github/workflows/run_tests.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,12 @@ on:
         type: boolean
         required: false
         default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+permissions:
+  contents: read
 
 env:
   UV_LINK_MODE: copy

--- a/docs/mkdocs/reference/renovate.md
+++ b/docs/mkdocs/reference/renovate.md
@@ -7,7 +7,17 @@ When Renovate notices changes it opens pull requests:
 - The first PR is an onboarding PR confirming the config and activating scheduled runs.
 - Subsequent PRs group updates by ecosystem (Python packages, npm packages, Docker images, GitHub Action versions).
 
-Every Renovate PR triggers our shared `Run Test Matrix` workflow through `.github/workflows/pr_tests.yml`, ensuring Python/Django compatibility stays intact. Merge PRs once the checks pass; major updates get a `major-upgrade` label for extra attention.
+Every Renovate PR triggers our shared `Run Test Matrix` workflow through `.github/workflows/pr_tests.yml`, ensuring Python/Django compatibility stays intact.
+
+Patch and minor updates can automerge after a seven-day release-age delay and passing CI. Renovate uses PR automerge rather than branch automerge, and platform-native automerge is disabled so the cooldown and CI state stay under Renovate control.
+
+Major updates are manual. Renovate labels them `major-upgrade` and requires dependency-dashboard approval before opening the PR.
+
+Treat these updates as manual even when they are not major:
+
+- Django, because it defines PowerCRUD's public compatibility matrix.
+- Lockfile maintenance, because it can refresh transitive dependency versions without a direct manifest update.
+
+The PR test workflows use explicit read-only `GITHUB_TOKEN` permissions. Do not add deploy, publish, or production secrets to dependency-update CI.
 
 If Renovate stalls, check the [Mend portal](https://developer.mend.io/github/doctor-cornelius/django-powercrud) to confirm the app still has access to the `dr-cornelius` organization and resync repositories from the Mend dashboard.
-

--- a/docs/mkdocs/reference/renovate.md
+++ b/docs/mkdocs/reference/renovate.md
@@ -2,6 +2,21 @@
 
 Renovate tracks all dependency surfaces in this repository (Python via `pyproject.toml`/`uv.lock`, npm, Dockerfiles, and GitHub Actions). The configuration lives in `renovate.json` on the default branch.
 
+## Operating Goal
+
+Use Renovate aggressively enough to keep dependency work routine, but not so aggressively that PowerCRUD silently absorbs breaking changes or very fresh compromised package releases.
+
+PowerCRUD is a Python package. Downstream projects do not inherit this repository's npm dependencies as npm transitive dependencies. The npm risk is still real because npm packages run during PowerCRUD's build and test workflow. A malicious npm dependency could affect CI, generated static assets, or the release artifact that downstream projects install from PyPI.
+
+The policy is therefore:
+
+- Automate low-risk dependency maintenance after a cooling-off period.
+- Keep framework compatibility and breaking-change decisions manual.
+- Keep dependency-update CI low-privilege.
+- Avoid broad secret exposure in ordinary dependency PR workflows.
+
+## Update Flow
+
 When Renovate notices changes it opens pull requests:
 
 - The first PR is an onboarding PR confirming the config and activating scheduled runs.
@@ -9,15 +24,47 @@ When Renovate notices changes it opens pull requests:
 
 Every Renovate PR triggers our shared `Run Test Matrix` workflow through `.github/workflows/pr_tests.yml`, ensuring Python/Django compatibility stays intact.
 
-Patch and minor updates can automerge after a seven-day release-age delay and passing CI. Renovate uses PR automerge rather than branch automerge, and platform-native automerge is disabled so the cooldown and CI state stay under Renovate control.
+## Automerge Policy
+
+Patch and minor updates can automerge when all of these are true:
+
+- The released version is at least seven days old.
+- Renovate's internal release-age check has passed.
+- The PR test matrix passes.
+- The dependency is not covered by a manual-review exception.
+
+Renovate uses PR automerge rather than branch automerge. Platform-native automerge is disabled so Renovate controls the cooldown, CI state, and merge decision.
 
 Major updates are manual. Renovate labels them `major-upgrade` and requires dependency-dashboard approval before opening the PR.
+
+## Manual Review Exceptions
 
 Treat these updates as manual even when they are not major:
 
 - Django, because it defines PowerCRUD's public compatibility matrix.
 - Lockfile maintenance, because it can refresh transitive dependency versions without a direct manifest update.
 
-The PR test workflows use explicit read-only `GITHUB_TOKEN` permissions. Do not add deploy, publish, or production secrets to dependency-update CI.
+For major updates, a human should identify the package role, skim release notes for breaking changes, wait for CI, and decide whether local or staging-style validation is needed before merging.
+
+## Supply-Chain Risk Controls
+
+The main supply-chain risk is a newly published package version that is malicious or compromised. This matters most for npm because dependency lifecycle scripts can run during install, before PowerCRUD code starts.
+
+PowerCRUD manages that risk with:
+
+- `minimumReleaseAge: "7 days"` for patch and minor automerge candidates.
+- `internalChecksFilter: "strict"` so updates do not get branches or PRs before the release-age check passes.
+- `npm ci` in CI, so installs use the committed lockfile rather than resolving loosely.
+- Manual lockfile maintenance, so transitive churn is visible before merge.
+
+## CI Permissions and Secrets
+
+Dependency PR CI should test and build, not deploy or publish.
+
+The PR test workflows use explicit read-only `GITHUB_TOKEN` permissions. The reusable test matrix receives only the Codecov token instead of inheriting every repository secret.
+
+Do not add deploy, publish, cloud, SSH, PyPI, npm, or production secrets to ordinary dependency-update CI.
+
+## Operations
 
 If Renovate stalls, check the [Mend portal](https://developer.mend.io/github/doctor-cornelius/django-powercrud) to confirm the app still has access to the `dr-cornelius` organization and resync repositories from the Mend dashboard.

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
   "prHourlyLimit": 2,
   "rebaseWhen": "conflicted",
   "dependencyDashboardAutoclose": true,
+  "platformAutomerge": false,
   "enabledManagers": [
     "poetry",
     "npm",
@@ -25,6 +26,7 @@
   ],
   "packageRules": [
     {
+      "description": "Group Python dependency updates.",
       "matchManagers": [
         "poetry"
       ],
@@ -33,6 +35,7 @@
       "additionalBranchPrefix": "python-"
     },
     {
+      "description": "Use lockfile-only updates for npm dependency ranges.",
       "matchManagers": [
         "npm"
       ],
@@ -40,6 +43,7 @@
       "additionalBranchPrefix": "js-"
     },
     {
+      "description": "Group npm patch and minor updates.",
       "matchManagers": [
         "npm"
       ],
@@ -51,6 +55,7 @@
       "groupSlug": "js-packages"
     },
     {
+      "description": "Group GitHub Actions updates.",
       "matchManagers": [
         "github-actions"
       ],
@@ -58,6 +63,7 @@
       "groupSlug": "github-actions"
     },
     {
+      "description": "Group Docker image updates.",
       "matchManagers": [
         "dockerfile"
       ],
@@ -65,46 +71,67 @@
       "groupSlug": "docker-images"
     },
     {
+      "description": "Automerge patch and minor updates after a release-age delay and passing CI.",
       "matchUpdateTypes": [
         "patch",
         "minor"
       ],
+      "minimumReleaseAge": "7 days",
+      "internalChecksFilter": "strict",
       "automerge": true,
-      "automergeType": "branch",
+      "automergeType": "pr",
       "addLabels": [
         "automerge"
       ]
     },
     {
+      "description": "Keep major updates manual.",
       "matchUpdateTypes": [
         "major"
       ],
-      "prCreation": "not-pending",
+      "dependencyDashboardApproval": true,
+      "automerge": false,
       "addLabels": [
         "major-upgrade"
       ]
     },
     {
-      "matchPackageNames": ["django", "Django"],
+      "description": "Keep Django updates manual because they define the public compatibility matrix.",
+      "matchPackageNames": [
+        "django",
+        "Django"
+      ],
       "allowedVersions": ">=5.2,<7",
-      "rangeStrategy": "update-lockfile"
+      "rangeStrategy": "update-lockfile",
+      "automerge": false
     },
     {
-      "matchManagers": ["poetry"],
-      "matchPackageNames": ["django-crispy-forms"],
+      "description": "Keep django-crispy-forms within the declared range.",
+      "matchManagers": [
+        "poetry"
+      ],
+      "matchPackageNames": [
+        "django-crispy-forms"
+      ],
       "rangeStrategy": "in-range-only"
     },
     {
-      "matchManagers": ["poetry"],
-      "matchPackageNames": ["pytest"],
-      "matchUpdateTypes": ["major"],
+      "description": "Do not raise pytest major updates automatically.",
+      "matchManagers": [
+        "poetry"
+      ],
+      "matchPackageNames": [
+        "pytest"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "enabled": false
     }
 
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true,
-    "automergeType": "branch"
+    "automerge": false
   }
 }


### PR DESCRIPTION
## Summary

- switch Renovate patch/minor automerge to PR automerge after a seven-day release-age delay
- keep major updates, Django updates, and lockfile maintenance manual
- reduce dependency PR CI privilege by using read-only workflow permissions and passing only the Codecov token to the reusable test matrix
- expand the Renovate reference docs with the policy and supply-chain risk model

## Verification

- `python -m json.tool renovate.json >/dev/null`
- `git diff --check`
