### PR TITLE
ci: harden dependency security scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,14 +32,14 @@ jobs:
           ignore-unfixed: true
           exit-code: 0
 
-      - name: Block critical filesystem vulnerabilities
+      - name: Block high and critical filesystem vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .
           format: table
           scanners: vuln,secret,misconfig
-          severity: CRITICAL
+          severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
           skip-setup-trivy: true
@@ -58,13 +58,13 @@ jobs:
           exit-code: 0
           skip-setup-trivy: true
 
-      - name: Block critical image vulnerabilities
+      - name: Block high and critical image vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: django-powercrud:${{ github.sha }}
           format: table
           vuln-type: os,library
-          severity: CRITICAL
+          severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
           skip-setup-trivy: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,6 +32,18 @@ jobs:
           ignore-unfixed: true
           exit-code: 0
 
+      - name: Block critical filesystem vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          scanners: vuln,secret,misconfig
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+          skip-setup-trivy: true
+
       - name: Build Django Docker image
         run: docker build -f docker/dockerfile_django -t django-powercrud:${{ github.sha }} .
 
@@ -44,6 +56,17 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 0
+          skip-setup-trivy: true
+
+      - name: Block critical image vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: django-powercrud:${{ github.sha }}
+          format: table
+          vuln-type: os,library
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
           skip-setup-trivy: true
 
   dependency-review:

--- a/docker/dockerfile_django
+++ b/docker/dockerfile_django
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
     apt-get install -y ca-certificates gnupg && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean && \

--- a/docker/dockerfile_django
+++ b/docker/dockerfile_django
@@ -4,6 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG PROJECT_DIR=django_powercrud
 ARG USER=devuser
 ARG USERHOME=/home/${USER}
+ARG NPM_VERSION=11.17.0
 ARG PROMPT_CODE='\n\[\e[0m\]🐳 \[\e[0m\][\[\e[0;38;5;226m\]$(git branch 2>/dev/null | grep '"'"'^*'"'"' | colrm 1 2)\[\e[0m\]] \[\e[0;91m\]\u\[\e[0m\]: \[\e[0;96m\]\w\n\[\e[0m\]\$\[\e[0m\] '
 
 ENV PYTHONUNBUFFERED=1 \
@@ -21,6 +22,7 @@ RUN apt-get update -y && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y nodejs && \
+    npm install -g npm@${NPM_VERSION} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -8,9 +8,11 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 
 - Renovate already applies a release delay and CI-gated automerge for patch/minor updates.
 - GitHub Actions runs Python/Django matrix tests and Playwright smoke checks.
-- CI does not currently build or scan the Docker image.
+- The new Security workflow builds and scans the Docker image with Trivy.
 - The repo commits `uv.lock`, `package-lock.json`, Docker config, and Django constraint files.
 - The repo is public on GitHub, so GitHub Dependency Review Action is available without paid GitHub Advanced Security.
+- Dependency Graph is enabled, so GitHub Dependency Review now runs successfully.
+- The root README has a Security workflow badge.
 
 ## Tool Disposition
 
@@ -33,4 +35,5 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 ## Deferred
 
 - Decide whether OSV-Scanner should run as PR-only, scheduled-only, or not at all after Trivy, GitHub Dependency Review, and Socket.dev are in place.
+- Decide whether to make Trivy blocking after reviewing the baseline output.
 - Record any intentionally ignored Trivy findings in a small, reviewable allowlist instead of burying them in workflow logic.

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -49,8 +49,19 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - For npm/image findings, identify whether vulnerable packages come from this repo's `package-lock.json`, built `node_modules`, or Node/npm tooling bundled into the Docker image.
 - Use the audit to choose fix, defer, or allowlist rather than blocking all `HIGH` findings immediately.
 
+## High Finding Audit Outcome
+
+- Python highs are stale transitive tooling entries in `uv.lock`, not core runtime dependencies.
+- `tornado` comes through `ipykernel -> jupyter-client`; refresh to at least `6.5.5`.
+- `urllib3` comes through docs/test tooling via `requests`; refresh to `2.7.0` to clear the listed highs.
+- Fix path: refresh affected lockfile packages with `uv lock --upgrade-package tornado --upgrade-package urllib3`.
+- npm/image highs are bundled npm tooling inside the Docker image, not this repo's `package-lock.json`.
+- Trivy pointed those findings at `/usr/lib/node_modules/npm/node_modules/...` for `cross-spawn`, `glob`, `minimatch`, and `tar`.
+- The project-installed image `node_modules` tree had no npm vulnerabilities in the Trivy run.
+- Fix path: update the Docker image Node/npm tooling, preferably by moving the NodeSource line forward and validating with the Security workflow.
+
 ## Deferred
 
 - Decide whether OSV-Scanner should run as PR-only, scheduled-only, or not at all after Trivy, GitHub Dependency Review, and Socket.dev are in place.
-- Decide which high findings should be fixed by dependency/image updates and which, if any, need a documented allowlist.
+- Decide whether any remaining high findings after the lockfile and Docker image updates need a documented allowlist.
 - Record any intentionally ignored Trivy findings in a small, reviewable allowlist instead of burying them in workflow logic.

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -54,7 +54,7 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - Python highs are stale transitive tooling entries in `uv.lock`, not core runtime dependencies.
 - `tornado` comes through `ipykernel -> jupyter-client`; refresh to at least `6.5.5`.
 - `urllib3` comes through docs/test tooling via `requests`; refresh to `2.7.0` to clear the listed highs.
-- Fix path: refresh affected lockfile packages with `uv lock --upgrade-package tornado --upgrade-package urllib3`.
+- Python lockfile fix applied on `security/dependency-hardening`: `tornado` `6.5.2` to `6.5.7` and `urllib3` `2.5.0` to `2.7.0`.
 - npm/image highs are bundled npm tooling inside the Docker image, not this repo's `package-lock.json`.
 - Trivy pointed those findings at `/usr/lib/node_modules/npm/node_modules/...` for `cross-spawn`, `glob`, `minimatch`, and `tar`.
 - The project-installed image `node_modules` tree had no npm vulnerabilities in the Trivy run.

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -29,11 +29,21 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 
 - Keep Trivy in CI only; do not add it to Python or npm project dependencies.
 - Scan both the repository/filesystem and the built Docker image.
-- Start with high-signal severities: `HIGH,CRITICAL`.
-- Use a non-blocking first pass if existing vulnerability noise is present, then tighten once the baseline is understood.
+- Keep `HIGH,CRITICAL` report scans so baseline detail remains visible.
+- Add critical-only gate scans so CI fails on `CRITICAL` findings.
+- Keep `HIGH` report-only until baseline findings are reviewed.
+
+## First Baseline Findings
+
+- Filesystem scan found 6 high findings and 0 critical findings in `uv.lock`.
+- The filesystem highs were for `tornado` and `urllib3`.
+- Image scan found 11 high findings and 0 critical findings.
+- The image highs included `cross-spawn`, `glob`, `minimatch`, and `tar` findings in npm/package metadata.
+- Socket Firewall passed and reported 0 npm install vulnerabilities.
+- Dependency Review passed and found no high-or-higher vulnerable dependency additions in the PR diff.
 
 ## Deferred
 
 - Decide whether OSV-Scanner should run as PR-only, scheduled-only, or not at all after Trivy, GitHub Dependency Review, and Socket.dev are in place.
-- Decide whether to make Trivy blocking after reviewing the baseline output.
+- Decide which high findings should be fixed by dependency/image updates and which, if any, need a documented allowlist.
 - Record any intentionally ignored Trivy findings in a small, reviewable allowlist instead of burying them in workflow logic.

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -30,8 +30,8 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - Keep Trivy in CI only; do not add it to Python or npm project dependencies.
 - Scan both the repository/filesystem and the built Docker image.
 - Keep `HIGH,CRITICAL` report scans so baseline detail remains visible.
-- Add critical-only gate scans so CI fails on `CRITICAL` findings.
-- Keep `HIGH` report-only until baseline findings are reviewed.
+- Gate scans now fail CI on `HIGH,CRITICAL` findings.
+- This was tightened only after the baseline findings were fixed and PR #140 confirmed clean scans.
 
 ## First Baseline Findings
 

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -42,6 +42,13 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - Socket Firewall passed and reported 0 npm install vulnerabilities.
 - Dependency Review passed and found no high-or-higher vulnerable dependency additions in the PR diff.
 
+## High Finding Audit Approach
+
+- Split the audit into two read-only lanes: Python lockfile findings and npm/image findings.
+- For Python findings, identify whether vulnerable packages are app/runtime dependencies or dev/test/docs transitive dependencies and whether Renovate can update them safely.
+- For npm/image findings, identify whether vulnerable packages come from this repo's `package-lock.json`, built `node_modules`, or Node/npm tooling bundled into the Docker image.
+- Use the audit to choose fix, defer, or allowlist rather than blocking all `HIGH` findings immediately.
+
 ## Deferred
 
 - Decide whether OSV-Scanner should run as PR-only, scheduled-only, or not at all after Trivy, GitHub Dependency Review, and Socket.dev are in place.

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -59,6 +59,7 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - Trivy pointed those findings at `/usr/lib/node_modules/npm/node_modules/...` for `cross-spawn`, `glob`, `minimatch`, and `tar`.
 - The project-installed image `node_modules` tree had no npm vulnerabilities in the Trivy run.
 - Docker image fix applied on `security/dependency-hardening`: move NodeSource from `node_20.x` to `node_22.x`.
+- Follow-up image fix applied on `security/dependency-hardening`: pin global npm to `11.17.0`, which bundles `picomatch` `4.0.4`.
 - Remaining validation: rebuild through the Security workflow and confirm the bundled npm findings clear or reduce.
 
 ## Deferred

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -58,7 +58,8 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - npm/image highs are bundled npm tooling inside the Docker image, not this repo's `package-lock.json`.
 - Trivy pointed those findings at `/usr/lib/node_modules/npm/node_modules/...` for `cross-spawn`, `glob`, `minimatch`, and `tar`.
 - The project-installed image `node_modules` tree had no npm vulnerabilities in the Trivy run.
-- Fix path: update the Docker image Node/npm tooling, preferably by moving the NodeSource line forward and validating with the Security workflow.
+- Docker image fix applied on `security/dependency-hardening`: move NodeSource from `node_20.x` to `node_22.x`.
+- Remaining validation: rebuild through the Security workflow and confirm the bundled npm findings clear or reduce.
 
 ## Deferred
 

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -60,10 +60,10 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - The project-installed image `node_modules` tree had no npm vulnerabilities in the Trivy run.
 - Docker image fix applied on `security/dependency-hardening`: move NodeSource from `node_20.x` to `node_22.x`.
 - Follow-up image fix applied on `security/dependency-hardening`: pin global npm to `11.17.0`, which bundles `picomatch` `4.0.4`.
-- Remaining validation: rebuild through the Security workflow and confirm the bundled npm findings clear or reduce.
+- Validation passed on PR #140: Trivy filesystem and image scans report 0 vulnerabilities for the configured `HIGH,CRITICAL` scan set.
+- No Trivy allowlist is currently needed.
 
 ## Deferred
 
 - Decide whether OSV-Scanner should run as PR-only, scheduled-only, or not at all after Trivy, GitHub Dependency Review, and Socket.dev are in place.
-- Decide whether any remaining high findings after the lockfile and Docker image updates need a documented allowlist.
-- Record any intentionally ignored Trivy findings in a small, reviewable allowlist instead of burying them in workflow logic.
+- Record any future intentionally ignored Trivy findings in a small, reviewable allowlist instead of burying them in workflow logic.

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Initial CI workflow implemented; awaiting first GitHub Actions baseline run.
+Initial CI workflow implemented and baseline runs passed on the PR branch and `main`.
 
 ## Next
 
-Review the first security workflow run, then decide whether Trivy should remain report-only or start blocking.
+Review Trivy output for actual high/critical findings, then decide whether Trivy should remain report-only or start blocking.
 
 ## Phase A: Baseline CI Security Scan
 
@@ -22,7 +22,7 @@ Review the first security workflow run, then decide whether Trivy should remain 
 
 ## Phase C: Rollout Tightening
 
-1. [ ] Review first-run findings and separate real fixes from baseline noise.
+1. [ ] Review first-run Trivy findings and separate real fixes from baseline noise.
 2. [ ] Decide whether Trivy should remain non-blocking or fail on `HIGH,CRITICAL`.
 3. [ ] Record any intentionally ignored findings in a small, reviewable allowlist.
 
@@ -37,7 +37,11 @@ Review the first security workflow run, then decide whether Trivy should remain 
 1. [x] Add Socket.dev selectively for npm supply-chain behaviour checks.
 2. [x] Keep the configuration focused on actionable npm risk for this repo.
 
-## Phase F: Optional OSV-Scanner
+## Phase F: README Badge
+
+1. [x] Add the Security workflow badge to the root README.
+
+## Phase G: Optional OSV-Scanner
 
 1. [ ] Consider OSV-Scanner only after Trivy, GitHub Dependency Review, and Socket.dev are in place.
 2. [ ] Add it only if it provides useful dependency vulnerability signal without duplicating too much noise.

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -36,7 +36,7 @@ Fix the audited high findings by refreshing the Python lockfile and updating the
 
 ## Phase E: Fix Audited High Findings
 
-1. [ ] Refresh `uv.lock` for the affected transitive Python packages.
+1. [x] Refresh `uv.lock` for the affected transitive Python packages.
 2. [x] Update Docker image Node/npm tooling so bundled npm package highs are removed where practical.
 3. [ ] Rerun Security workflow and confirm high findings are reduced or cleared.
 4. [ ] Decide whether any remaining highs need a small documented allowlist.

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -37,7 +37,7 @@ Fix the audited high findings by refreshing the Python lockfile and updating the
 ## Phase E: Fix Audited High Findings
 
 1. [ ] Refresh `uv.lock` for the affected transitive Python packages.
-2. [ ] Update Docker image Node/npm tooling so bundled npm package highs are removed where practical.
+2. [x] Update Docker image Node/npm tooling so bundled npm package highs are removed where practical.
 3. [ ] Rerun Security workflow and confirm high findings are reduced or cleared.
 4. [ ] Decide whether any remaining highs need a small documented allowlist.
 

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -6,7 +6,7 @@ Initial CI workflow implemented, baseline runs passed, and Trivy is being tighte
 
 ## Next
 
-Review the existing high findings and decide which are fixable dependency updates versus acceptable dev-image/tooling baseline noise.
+Complete the high-finding audit and decide which findings are fixable dependency updates versus acceptable dev-image/tooling baseline noise.
 
 ## Phase A: Baseline CI Security Scan
 
@@ -24,25 +24,32 @@ Review the existing high findings and decide which are fixable dependency update
 
 1. [x] Review first-run Trivy findings and separate critical policy from high baseline noise.
 2. [x] Keep high findings report-only for now and fail CI on critical findings.
-3. [ ] Review high findings and decide fix, defer, or allowlist.
+3. [ ] Confirm the critical-only gate passes on the hardening branch.
 4. [ ] Record any intentionally ignored findings in a small, reviewable allowlist.
 
-## Phase D: GitHub Dependency Review
+## Phase D: High Finding Audit
+
+1. [ ] Audit Python `uv.lock` highs and identify whether they are runtime, test/dev, docs, or tool dependencies.
+2. [ ] Audit npm/image highs and identify whether they come from the repo npm tree or bundled Node/npm tooling in the Docker image.
+3. [ ] Decide per finding group: fix now, defer behind Renovate, or document as baseline/tooling noise.
+4. [ ] Update notes with the audit outcome and next fix branch, if needed.
+
+## Phase E: GitHub Dependency Review
 
 1. [x] Add GitHub Dependency Review Action for pull requests after Trivy is working.
 2. [x] Configure it as a PR dependency-diff check for this public GitHub repo.
 3. [x] Keep it secondary to Trivy rather than treating it as the main scanner.
 
-## Phase E: Socket.dev
+## Phase F: Socket.dev
 
 1. [x] Add Socket.dev selectively for npm supply-chain behaviour checks.
 2. [x] Keep the configuration focused on actionable npm risk for this repo.
 
-## Phase F: README Badge
+## Phase G: README Badge
 
 1. [x] Add the Security workflow badge to the root README.
 
-## Phase G: Optional OSV-Scanner
+## Phase H: Optional OSV-Scanner
 
 1. [ ] Consider OSV-Scanner only after Trivy, GitHub Dependency Review, and Socket.dev are in place.
 2. [ ] Add it only if it provides useful dependency vulnerability signal without duplicating too much noise.

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Initial CI workflow implemented and baseline runs passed on the PR branch and `main`.
+Initial CI workflow implemented, baseline runs passed, and Trivy is being tightened to block critical findings.
 
 ## Next
 
-Review Trivy output for actual high/critical findings, then decide whether Trivy should remain report-only or start blocking.
+Review the existing high findings and decide which are fixable dependency updates versus acceptable dev-image/tooling baseline noise.
 
 ## Phase A: Baseline CI Security Scan
 
@@ -22,9 +22,10 @@ Review Trivy output for actual high/critical findings, then decide whether Trivy
 
 ## Phase C: Rollout Tightening
 
-1. [ ] Review first-run Trivy findings and separate real fixes from baseline noise.
-2. [ ] Decide whether Trivy should remain non-blocking or fail on `HIGH,CRITICAL`.
-3. [ ] Record any intentionally ignored findings in a small, reviewable allowlist.
+1. [x] Review first-run Trivy findings and separate critical policy from high baseline noise.
+2. [x] Keep high findings report-only for now and fail CI on critical findings.
+3. [ ] Review high findings and decide fix, defer, or allowlist.
+4. [ ] Record any intentionally ignored findings in a small, reviewable allowlist.
 
 ## Phase D: GitHub Dependency Review
 

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Initial CI workflow implemented, baseline runs passed, and Trivy is being tightened to block critical findings.
+Initial CI workflow implemented, baseline findings fixed, and Trivy critical gates pass.
 
 ## Next
 
-Fix the audited high findings by refreshing the Python lockfile and updating the Docker image Node/npm tooling, then rerun the Security workflow.
+Review draft PR #140 and decide whether to mark it ready for merge.
 
 ## Phase A: Baseline CI Security Scan
 
@@ -24,8 +24,8 @@ Fix the audited high findings by refreshing the Python lockfile and updating the
 
 1. [x] Review first-run Trivy findings and separate critical policy from high baseline noise.
 2. [x] Keep high findings report-only for now and fail CI on critical findings.
-3. [ ] Confirm the critical-only gate passes on the hardening branch.
-4. [ ] Record any intentionally ignored findings in a small, reviewable allowlist.
+3. [x] Confirm the critical-only gate passes on the hardening branch.
+4. [x] Confirm no allowlist is needed for the current baseline.
 
 ## Phase D: High Finding Audit
 
@@ -38,8 +38,8 @@ Fix the audited high findings by refreshing the Python lockfile and updating the
 
 1. [x] Refresh `uv.lock` for the affected transitive Python packages.
 2. [x] Update Docker image Node/npm tooling so bundled npm package highs are removed where practical.
-3. [ ] Rerun Security workflow and confirm high findings are reduced or cleared.
-4. [ ] Decide whether any remaining highs need a small documented allowlist.
+3. [x] Rerun Security workflow and confirm high findings are reduced or cleared.
+4. [x] Decide whether any remaining highs need a small documented allowlist.
 
 ## Phase F: GitHub Dependency Review
 

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -6,7 +6,7 @@ Initial CI workflow implemented, baseline runs passed, and Trivy is being tighte
 
 ## Next
 
-Complete the high-finding audit and decide which findings are fixable dependency updates versus acceptable dev-image/tooling baseline noise.
+Fix the audited high findings by refreshing the Python lockfile and updating the Docker image Node/npm tooling, then rerun the Security workflow.
 
 ## Phase A: Baseline CI Security Scan
 
@@ -29,27 +29,34 @@ Complete the high-finding audit and decide which findings are fixable dependency
 
 ## Phase D: High Finding Audit
 
-1. [ ] Audit Python `uv.lock` highs and identify whether they are runtime, test/dev, docs, or tool dependencies.
-2. [ ] Audit npm/image highs and identify whether they come from the repo npm tree or bundled Node/npm tooling in the Docker image.
-3. [ ] Decide per finding group: fix now, defer behind Renovate, or document as baseline/tooling noise.
-4. [ ] Update notes with the audit outcome and next fix branch, if needed.
+1. [x] Audit Python `uv.lock` highs and identify whether they are runtime, test/dev, docs, or tool dependencies.
+2. [x] Audit npm/image highs and identify whether they come from the repo npm tree or bundled Node/npm tooling in the Docker image.
+3. [x] Decide per finding group: fix now, defer behind Renovate, or document as baseline/tooling noise.
+4. [x] Update notes with the audit outcome and next fix branch, if needed.
 
-## Phase E: GitHub Dependency Review
+## Phase E: Fix Audited High Findings
+
+1. [ ] Refresh `uv.lock` for the affected transitive Python packages.
+2. [ ] Update Docker image Node/npm tooling so bundled npm package highs are removed where practical.
+3. [ ] Rerun Security workflow and confirm high findings are reduced or cleared.
+4. [ ] Decide whether any remaining highs need a small documented allowlist.
+
+## Phase F: GitHub Dependency Review
 
 1. [x] Add GitHub Dependency Review Action for pull requests after Trivy is working.
 2. [x] Configure it as a PR dependency-diff check for this public GitHub repo.
 3. [x] Keep it secondary to Trivy rather than treating it as the main scanner.
 
-## Phase F: Socket.dev
+## Phase G: Socket.dev
 
 1. [x] Add Socket.dev selectively for npm supply-chain behaviour checks.
 2. [x] Keep the configuration focused on actionable npm risk for this repo.
 
-## Phase G: README Badge
+## Phase H: README Badge
 
 1. [x] Add the Security workflow badge to the root README.
 
-## Phase H: Optional OSV-Scanner
+## Phase I: Optional OSV-Scanner
 
 1. [ ] Consider OSV-Scanner only after Trivy, GitHub Dependency Review, and Socket.dev are in place.
 2. [ ] Add it only if it provides useful dependency vulnerability signal without duplicating too much noise.

--- a/docs/_plans/dependency_security/dependency_security-plan.md
+++ b/docs/_plans/dependency_security/dependency_security-plan.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Initial CI workflow implemented, baseline findings fixed, and Trivy critical gates pass.
+Initial CI workflow implemented, baseline findings fixed, and Trivy gates now block high and critical findings.
 
 ## Next
 
-Review draft PR #140 and decide whether to mark it ready for merge.
+Finish PR #140 and clean up the feature branch.
 
 ## Phase A: Baseline CI Security Scan
 
@@ -23,8 +23,8 @@ Review draft PR #140 and decide whether to mark it ready for merge.
 ## Phase C: Rollout Tightening
 
 1. [x] Review first-run Trivy findings and separate critical policy from high baseline noise.
-2. [x] Keep high findings report-only for now and fail CI on critical findings.
-3. [x] Confirm the critical-only gate passes on the hardening branch.
+2. [x] Keep high findings report-only while baseline findings are reviewed.
+3. [x] Tighten Trivy gates to fail CI on high and critical findings after the baseline is clean.
 4. [x] Confirm no allowlist is needed for the current baseline.
 
 ## Phase D: High Finding Audit

--- a/uv.lock
+++ b/uv.lock
@@ -1801,21 +1801,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.2"
+version = "6.5.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/ce/1eb500eae19f4648281bb2186927bb062d2438c2e5093d1360391afd2f90/tornado-6.5.2.tar.gz", hash = "sha256:ab53c8f9a0fa351e2c0741284e06c7a45da86afb544133201c5cc8578eb076a0", size = 510821, upload-time = "2025-08-08T18:27:00.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/48/6a7529df2c9cc12efd2e8f5dd219516184d703b34c06786809670df5b3bd/tornado-6.5.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2436822940d37cde62771cff8774f4f00b3c8024fe482e16ca8387b8a2724db6", size = 442563, upload-time = "2025-08-08T18:26:42.945Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/b5/9b575a0ed3e50b00c40b08cbce82eb618229091d09f6d14bce80fc01cb0b/tornado-6.5.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:583a52c7aa94ee046854ba81d9ebb6c81ec0fd30386d96f7640c96dad45a03ef", size = 440729, upload-time = "2025-08-08T18:26:44.473Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/4e/619174f52b120efcf23633c817fd3fed867c30bff785e2cd5a53a70e483c/tornado-6.5.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0fe179f28d597deab2842b86ed4060deec7388f1fd9c1b4a41adf8af058907e", size = 444295, upload-time = "2025-08-08T18:26:46.021Z" },
-    { url = "https://files.pythonhosted.org/packages/95/fa/87b41709552bbd393c85dd18e4e3499dcd8983f66e7972926db8d96aa065/tornado-6.5.2-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b186e85d1e3536d69583d2298423744740986018e393d0321df7340e71898882", size = 443644, upload-time = "2025-08-08T18:26:47.625Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/41/fb15f06e33d7430ca89420283a8762a4e6b8025b800ea51796ab5e6d9559/tornado-6.5.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e792706668c87709709c18b353da1f7662317b563ff69f00bab83595940c7108", size = 443878, upload-time = "2025-08-08T18:26:50.599Z" },
-    { url = "https://files.pythonhosted.org/packages/11/92/fe6d57da897776ad2e01e279170ea8ae726755b045fe5ac73b75357a5a3f/tornado-6.5.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:06ceb1300fd70cb20e43b1ad8aaee0266e69e7ced38fa910ad2e03285009ce7c", size = 444549, upload-time = "2025-08-08T18:26:51.864Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/02/c8f4f6c9204526daf3d760f4aa555a7a33ad0e60843eac025ccfd6ff4a93/tornado-6.5.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:74db443e0f5251be86cbf37929f84d8c20c27a355dd452a5cfa2aada0d001ec4", size = 443973, upload-time = "2025-08-08T18:26:53.625Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/2d/f5f5707b655ce2317190183868cd0f6822a1121b4baeae509ceb9590d0bd/tornado-6.5.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b5e735ab2889d7ed33b32a459cac490eda71a1ba6857b0118de476ab6c366c04", size = 443954, upload-time = "2025-08-08T18:26:55.072Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/59/593bd0f40f7355806bf6573b47b8c22f8e1374c9b6fd03114bd6b7a3dcfd/tornado-6.5.2-cp39-abi3-win32.whl", hash = "sha256:c6f29e94d9b37a95013bb669616352ddb82e3bfe8326fccee50583caebc8a5f0", size = 445023, upload-time = "2025-08-08T18:26:56.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/2a/f609b420c2f564a748a2d80ebfb2ee02a73ca80223af712fca591386cafb/tornado-6.5.2-cp39-abi3-win_amd64.whl", hash = "sha256:e56a5af51cc30dd2cae649429af65ca2f6571da29504a07995175df14c18f35f", size = 445427, upload-time = "2025-08-08T18:26:57.91Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/4f/e1f65e8f8c76d73658b33d33b81eed4322fb5085350e4328d5c956f0c8f9/tornado-6.5.2-cp39-abi3-win_arm64.whl", hash = "sha256:d6c33dc3672e3a1f3618eb63b7ef4683a7688e7b9e6e8f0d9aa5726360a004af", size = 444456, upload-time = "2025-08-08T18:26:59.207Z" },
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
 ]
 
 [[package]]
@@ -1859,11 +1857,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- fail the Security workflow on critical Trivy filesystem and image findings
- refresh the vulnerable Python lockfile transitive packages identified by Trivy
- move the Docker image NodeSource line from Node 20 to Node 22 to address bundled npm tooling findings
- update dependency-security planning notes with the audit and rollout state

## Validation

- `git diff --check`
- CI/Security workflow should validate the rebuilt image and scans on this PR

## Notes

This PR keeps HIGH Trivy findings report-only while blocking CRITICAL findings. Any remaining HIGH findings after CI should be reviewed before adding an allowlist.
