### PR TITLE
Sample runtime metadata and alpha beta releases

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -31,7 +31,7 @@ jobs:
           import tomllib
 
           release_version = os.environ["RELEASE_VERSION"]
-          if not re.fullmatch(r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?", release_version):
+          if not re.fullmatch(r"\d+\.\d+\.\d+(?:(?:a|b)\d+)?", release_version):
               raise SystemExit(f"Tag {release_version!r} is not a publishable release tag")
 
           data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,10 @@ jobs:
           import re
 
           tag_name = os.environ["TAG_NAME"]
-          if not re.fullmatch(r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?", tag_name):
+          if not re.fullmatch(r"\d+\.\d+\.\d+(?:(?:a|b)\d+)?", tag_name):
               raise SystemExit(f"Tag {tag_name!r} is not a publishable release tag")
 
-          prerelease = re.search(r"(?:a|b|rc)\d+$", tag_name) is not None
+          prerelease = re.search(r"(?:a|b)\d+$", tag_name) is not None
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               print(f"version={tag_name}", file=fh)
               print(f"prerelease={'true' if prerelease else 'false'}", file=fh)

--- a/docs/mkdocs/reference/dockerised_dev.md
+++ b/docs/mkdocs/reference/dockerised_dev.md
@@ -193,6 +193,8 @@ git pull --ff-only origin main
 
 `--prepare` creates a `release/<version>` branch and delegates validation/build/lock work to the dev container. `--publish` runs from the host shell with `gh` authenticated, opens and merges the release PR with a semantic squash subject, updates local `main`, then pushes the version tag that triggers the PyPI and documentation workflows.
 
+Prereleases use the same flow with PEP 440 alpha/beta labels only, for example `./new_release.sh --prepare minor --prerelease alpha`. Release candidates are intentionally unsupported.
+
 For agent-driven branch finish work, see `AGENTS/AGENTS_pr_workflow.md` in the repository root.
 
 ### 8. **Shutdown**

--- a/new_release.sh
+++ b/new_release.sh
@@ -6,7 +6,7 @@ STATE_FILE=".git/new_release_state.json"
 function show_help {
     cat <<'EOF'
 Usage:
-  ./new_release.sh --prepare <patch|minor|major> [--prerelease <alpha|beta|rc>] [--breaking-notes-file <path>]
+  ./new_release.sh --prepare <patch|minor|major> [--prerelease <alpha|beta>] [--breaking-notes-file <path>]
   ./new_release.sh --publish
   ./new_release.sh --abort
   ./new_release.sh --help
@@ -287,7 +287,7 @@ import sys
 
 text = pathlib.Path("pyproject.toml").read_text(encoding="utf-8")
 match = re.search(
-    r'^version\s*=\s*"(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)"\s*$',
+    r'^version\s*=\s*"(?P<version>\d+\.\d+\.\d+(?:(?:a|b)\d+)?)"\s*$',
     text,
     re.M,
 )
@@ -297,7 +297,7 @@ if not match:
 version_text = match.group("version")
 parsed = re.fullmatch(
     r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
-    r"(?:(?P<pre_kind>a|b|rc)(?P<pre_num>\d+))?",
+    r"(?:(?P<pre_kind>a|b)(?P<pre_num>\d+))?",
     version_text,
 )
 if not parsed:
@@ -312,8 +312,8 @@ is_prerelease = current_pre_kind is not None
 
 bump = sys.argv[1]
 requested_prerelease = sys.argv[2]
-requested_suffix = {"": "", "alpha": "a", "beta": "b", "rc": "rc"}[requested_prerelease]
-prerelease_order = {"a": 0, "b": 1, "rc": 2}
+requested_suffix = {"": "", "alpha": "a", "beta": "b"}[requested_prerelease]
+prerelease_order = {"a": 0, "b": 1}
 
 if bump == "major":
     target = (major + 1, 0, 0)
@@ -356,7 +356,7 @@ new_version = sys.argv[1]
 path = pathlib.Path("pyproject.toml")
 text = path.read_text(encoding="utf-8")
 new_text = re.sub(
-    r'(version\s*=\s*")(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)(")',
+    r'(version\s*=\s*")(\d+\.\d+\.\d+(?:(?:a|b)\d+)?)(")',
     lambda m: f'{m.group(1)}{new_version}{m.group(3)}',
     text,
     count=1,
@@ -1015,14 +1015,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --prerelease)
             if [[ $# -lt 2 ]]; then
-                die "--prerelease requires alpha, beta, or rc."
+                die "--prerelease requires alpha or beta."
             fi
             case "$2" in
-                alpha|beta|rc)
+                alpha|beta)
                     PRERELEASE_KIND="$2"
                     ;;
                 *)
-                    die "--prerelease must be one of alpha, beta, or rc."
+                    die "--prerelease must be alpha or beta."
                     ;;
             esac
             shift 2

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -103,6 +103,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "sample.context_processors.app_meta",
             ],
             "builtins": [
                 "django.templatetags.i18n",

--- a/src/sample/context_processors.py
+++ b/src/sample/context_processors.py
@@ -1,0 +1,78 @@
+"""Context processors for the bundled sample app."""
+
+from functools import lru_cache
+from importlib import metadata
+import os
+from pathlib import Path
+import subprocess
+import tomllib
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def app_meta(request):
+    """Return runtime metadata displayed by the local sample app shell."""
+    return {
+        "sample_app_env": _first_env("APP_ENV", "DJANGO_ENV", "DJANGO_LIFECYCLE_ENV")
+        or "dev",
+        "sample_package_version": _package_version(),
+        "sample_git_version": os.environ.get("APP_VERSION") or _git_describe(),
+        "sample_git_commit": os.environ.get("APP_COMMIT") or _git_commit(),
+    }
+
+
+def _first_env(*names):
+    """Return the first populated environment variable from names."""
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return ""
+
+
+@lru_cache(maxsize=1)
+def _package_version():
+    """Return the installed package version or the local pyproject fallback."""
+    try:
+        return metadata.version("django-powercrud")
+    except metadata.PackageNotFoundError:
+        return _pyproject_version()
+
+
+def _pyproject_version():
+    """Return the local pyproject version when running from an editable checkout."""
+    pyproject_path = PROJECT_ROOT / "pyproject.toml"
+    try:
+        project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]
+    except (FileNotFoundError, KeyError, tomllib.TOMLDecodeError):
+        return "unknown"
+    return str(project.get("version") or "unknown")
+
+
+@lru_cache(maxsize=1)
+def _git_describe():
+    """Return a human-readable git description for the current checkout."""
+    return _git_output(["git", "describe", "--tags", "--always", "--dirty"], "dev")
+
+
+@lru_cache(maxsize=1)
+def _git_commit():
+    """Return the short commit hash for the current checkout."""
+    return _git_output(["git", "rev-parse", "--short", "HEAD"], "unknown")
+
+
+def _git_output(command, fallback):
+    """Run a git command in the project root and return a safe fallback on failure."""
+    try:
+        result = subprocess.run(
+            command,
+            cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return fallback
+    return result.stdout.strip() or fallback

--- a/src/sample/templates/sample/_runtime_meta.html
+++ b/src/sample/templates/sample/_runtime_meta.html
@@ -1,0 +1,10 @@
+<div class="flex w-fit max-w-full flex-wrap items-center gap-y-1 rounded border border-base-300 bg-base-200/70 px-2 py-1 text-xs text-base-content/70"
+     data-sample-runtime-meta="true">
+    <span class="font-medium">{{ sample_app_env }}</span>
+    <span class="mx-1 text-base-content/40">&middot;</span>
+    <span>django-powercrud {{ sample_package_version }}</span>
+    <span class="mx-1 text-base-content/40">&middot;</span>
+    <span>{{ sample_git_version }}</span>
+    <span class="mx-1 text-base-content/40">&middot;</span>
+    <span>{{ sample_git_commit }}</span>
+</div>

--- a/src/sample/templates/sample/daisyUI/base.html
+++ b/src/sample/templates/sample/daisyUI/base.html
@@ -25,6 +25,7 @@
     {% block app_content %}{% endblock app_content %}
 
     <div class="container mx-5 my-5 p-5">
+        {% include "sample/_runtime_meta.html" %}
         <nav class="mb-5 flex flex-wrap items-center gap-2" aria-label="Sample navigation">
             <label class="swap swap-rotate btn btn-sm btn-outline btn-secondary btn-square"
                    aria-label="Select Dark Theme"

--- a/src/sample/templates/sample/manual_static/base.html
+++ b/src/sample/templates/sample/manual_static/base.html
@@ -32,6 +32,9 @@
     {% block app_content %}{% endblock app_content %}
 
     <div class="container mx-5 my-5 p-5">
+        <div class="mb-5">
+            {% include "sample/_runtime_meta.html" %}
+        </div>
         <div id="content">
             {% block content %}{% endblock content %}
             <div id="powercrud"></div>

--- a/src/tests/settings.py
+++ b/src/tests/settings.py
@@ -70,6 +70,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "sample.context_processors.app_meta",
             ],
             "debug": True,
             "builtins": [

--- a/src/tests/test_frontend_asset_packaging.py
+++ b/src/tests/test_frontend_asset_packaging.py
@@ -188,8 +188,14 @@ def test_sample_templates_cover_vite_and_manual_static_loading_modes() -> None:
     assert "{% vite_asset 'config/static/js/main.js' %}" in vite_template, (
         "The normal sample base should continue to exercise the Vite manifest entry."
     )
+    assert '{% include "sample/_runtime_meta.html" %}' in vite_template, (
+        "The normal sample base should include the shared runtime metadata footer."
+    )
     assert "django_vite" not in manual_template, (
         "The manual-static sample base should not load django-vite tags."
+    )
+    assert '{% include "sample/_runtime_meta.html" %}' in manual_template, (
+        "The manual-static sample base should include the shared runtime metadata footer."
     )
     assert "{% static 'powercrud/css/powercrud.css' %}" in manual_template, (
         "The manual-static sample base should load PowerCRUD CSS through Django static tags."

--- a/src/tests/test_release_policy.py
+++ b/src/tests/test_release_policy.py
@@ -1,0 +1,42 @@
+"""Static checks for PowerCRUD release-version policy."""
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_release_script_allows_only_alpha_and_beta_prereleases():
+    """The local release helper should not advertise or accept release candidates."""
+    release_script = (PROJECT_ROOT / "new_release.sh").read_text(encoding="utf-8")
+
+    assert "<alpha|beta>" in release_script, (
+        "new_release.sh help should advertise only alpha and beta prereleases."
+    )
+    assert "<alpha|beta|rc>" not in release_script, (
+        "new_release.sh help should not advertise rc prereleases."
+    )
+    assert "alpha|beta|rc" not in release_script, (
+        "new_release.sh argument parsing should not accept rc prereleases."
+    )
+    assert "a|b|rc" not in release_script, (
+        "new_release.sh version regexes should not accept rc suffixes."
+    )
+    assert '"rc": "rc"' not in release_script, (
+        "new_release.sh prerelease mapping should not contain an rc suffix."
+    )
+
+
+def test_release_workflows_reject_rc_tags():
+    """Release workflows should validate the same alpha/beta policy as the script."""
+    publish_workflow = (PROJECT_ROOT / ".github" / "workflows" / "publish.yml")
+    docs_workflow = (PROJECT_ROOT / ".github" / "workflows" / "deploy_docs.yml")
+
+    for workflow_path in (publish_workflow, docs_workflow):
+        workflow = workflow_path.read_text(encoding="utf-8")
+        assert "(?:a|b)\\d+" in workflow, (
+            f"{workflow_path.name} should accept only alpha and beta PEP 440 tags."
+        )
+        assert "a|b|rc" not in workflow, (
+            f"{workflow_path.name} should not validate rc tags as publishable."
+        )

--- a/src/tests/test_sample_runtime_metadata.py
+++ b/src/tests/test_sample_runtime_metadata.py
@@ -1,0 +1,190 @@
+"""Tests for the bundled sample app runtime metadata footer."""
+
+from subprocess import CalledProcessError
+
+import pytest
+from django.urls import reverse
+from importlib import metadata
+
+from sample import context_processors
+from sample.models import Author, Book
+
+
+def _clear_metadata_caches():
+    """Clear cached metadata helpers so each test controls its own inputs."""
+    context_processors._package_version.cache_clear()
+    context_processors._git_describe.cache_clear()
+    context_processors._git_commit.cache_clear()
+
+
+def _clear_metadata_environment(monkeypatch):
+    """Remove runtime metadata env vars so fallback tests are deterministic."""
+    for name in (
+        "APP_ENV",
+        "DJANGO_ENV",
+        "DJANGO_LIFECYCLE_ENV",
+        "APP_VERSION",
+        "APP_COMMIT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def clear_sample_metadata_caches():
+    """Reset sample metadata caches around each test."""
+    _clear_metadata_caches()
+    yield
+    _clear_metadata_caches()
+
+
+def test_sample_app_meta_prefers_explicit_environment_values(monkeypatch):
+    """Explicit runtime environment variables should win over computed values."""
+    monkeypatch.setenv("APP_ENV", "preview")
+    monkeypatch.setenv("APP_VERSION", "0.8.0a1")
+    monkeypatch.setenv("APP_COMMIT", "abc1234")
+    monkeypatch.setattr(
+        context_processors.metadata,
+        "version",
+        lambda package: "0.7.13",
+    )
+
+    context = context_processors.app_meta(None)
+
+    assert context == {
+        "sample_app_env": "preview",
+        "sample_package_version": "0.7.13",
+        "sample_git_version": "0.8.0a1",
+        "sample_git_commit": "abc1234",
+    }, "Explicit sample app metadata environment values should be exposed unchanged."
+
+
+def test_sample_app_meta_falls_back_to_git_and_pyproject(monkeypatch, tmp_path):
+    """Local editable checkouts should fall back to pyproject and git metadata."""
+    _clear_metadata_environment(monkeypatch)
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "django-powercrud"\nversion = "0.8.0a1"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(context_processors, "PROJECT_ROOT", tmp_path)
+
+    def fake_version(package):
+        raise metadata.PackageNotFoundError(package)
+
+    def fake_run(command, **kwargs):
+        class Result:
+            stdout = ""
+
+        result = Result()
+        if command[:3] == ["git", "describe", "--tags"]:
+            result.stdout = "0.8.0a1-2-gabc1234-dirty\n"
+            return result
+        if command[:3] == ["git", "rev-parse", "--short"]:
+            result.stdout = "abc1234\n"
+            return result
+        raise AssertionError(f"Unexpected git command: {command}")
+
+    monkeypatch.setattr(context_processors.metadata, "version", fake_version)
+    monkeypatch.setattr(context_processors.subprocess, "run", fake_run)
+
+    context = context_processors.app_meta(None)
+
+    assert context["sample_app_env"] == "dev", (
+        "Missing environment metadata should default the sample app env to dev."
+    )
+    assert context["sample_package_version"] == "0.8.0a1", (
+        "Editable checkouts should expose the pyproject package version."
+    )
+    assert context["sample_git_version"] == "0.8.0a1-2-gabc1234-dirty", (
+        "Local checkouts should expose git describe output when available."
+    )
+    assert context["sample_git_commit"] == "abc1234", (
+        "Local checkouts should expose the short git commit when available."
+    )
+
+
+def test_sample_app_meta_uses_safe_fallbacks_when_git_and_package_fail(
+    monkeypatch, tmp_path
+):
+    """Runtime metadata should remain renderable when package and git lookups fail."""
+    _clear_metadata_environment(monkeypatch)
+    monkeypatch.setattr(context_processors, "PROJECT_ROOT", tmp_path)
+
+    def fake_version(package):
+        raise metadata.PackageNotFoundError(package)
+
+    def fake_run(command, **kwargs):
+        raise CalledProcessError(128, command)
+
+    monkeypatch.setattr(context_processors.metadata, "version", fake_version)
+    monkeypatch.setattr(context_processors.subprocess, "run", fake_run)
+
+    context = context_processors.app_meta(None)
+
+    assert context["sample_package_version"] == "unknown", (
+        "Missing package metadata and pyproject should fall back to unknown."
+    )
+    assert context["sample_git_version"] == "dev", (
+        "Failed git describe should fall back to dev."
+    )
+    assert context["sample_git_commit"] == "unknown", (
+        "Failed git commit lookup should fall back to unknown."
+    )
+
+
+@pytest.mark.django_db
+def test_sample_home_full_page_includes_runtime_metadata_footer(client):
+    """The sample home shell should include one persistent runtime metadata footer."""
+    response = client.get(reverse("home"))
+
+    assert response.status_code == 200, "The sample home page should render."
+    response_text = response.content.decode()
+    assert response_text.count('data-sample-runtime-meta="true"') == 1, (
+        "The full-page sample home response should include exactly one metadata footer."
+    )
+
+
+@pytest.mark.django_db
+def test_sample_powercrud_full_page_includes_runtime_metadata_footer(client):
+    """PowerCRUD sample screens should include the shell-level metadata footer."""
+    author = Author.objects.create(name="Runtime Metadata Author")
+    Book.objects.create(
+        title="Runtime Metadata Book",
+        author=author,
+        published_date="2024-01-01",
+        bestseller=False,
+        isbn="9780000000990",
+        pages=101,
+    )
+
+    response = client.get(reverse("sample:bigbook-list"))
+
+    assert response.status_code == 200, "The sample Book list should render."
+    response_text = response.content.decode()
+    assert response_text.count('data-sample-runtime-meta="true"') == 1, (
+        "Full-page PowerCRUD sample responses should include one metadata footer."
+    )
+
+
+@pytest.mark.django_db
+def test_sample_manual_static_full_page_includes_runtime_metadata_footer(client):
+    """The manual-static sample shell should show the same metadata footer."""
+    response = client.get(reverse("sample:manual-static-bigbook-list"))
+
+    assert response.status_code == 200, "The manual-static Book list should render."
+    response_text = response.content.decode()
+    assert response_text.count('data-sample-runtime-meta="true"') == 1, (
+        "The manual-static sample response should include one metadata footer."
+    )
+
+
+@pytest.mark.django_db
+def test_sample_htmx_partial_does_not_render_runtime_metadata_footer(client):
+    """HTMX partial responses should not duplicate the persistent shell footer."""
+    response = client.get(reverse("home"), HTTP_HX_REQUEST="true")
+
+    assert response.status_code == 200, "The sample home HTMX partial should render."
+    response_text = response.content.decode()
+    assert 'data-sample-runtime-meta="true"' not in response_text, (
+        "HTMX partial responses should leave the shell-level metadata footer alone."
+    )


### PR DESCRIPTION
## Summary
- surface sample-app runtime metadata in the sample shell using a context processor
- restrict package prerelease support to PEP 440 alpha/beta only
- align publish/docs release workflows and docs with the alpha/beta policy

## Verification
- bash -n new_release.sh
- git diff --check
- ./runproj exec --command "./runtests --pytest src/tests/test_sample_runtime_metadata.py src/tests/test_release_policy.py src/tests/test_frontend_asset_packaging.py src/sample/tests/test_view_filters.py"
