### PR TITLE
test(favourites): retry filter panel toggle after swaps

### DIFF
--- a/src/tests/playwright/test_filter_favourites.py
+++ b/src/tests/playwright/test_filter_favourites.py
@@ -69,7 +69,17 @@ def open_filters_panel(page):
     expect(toggle).to_be_visible()
     if re.search(r"\bhidden\b", filter_panel.get_attribute("class") or ""):
         toggle.click(force=True)
-    expect(filter_panel).not_to_have_class(re.compile(r"\bhidden\b"))
+    try:
+        expect(filter_panel).not_to_have_class(re.compile(r"\bhidden\b"), timeout=1500)
+    except AssertionError:
+        # HTMX list swaps can leave the first click racing the refreshed toolbar.
+        # Re-resolve the controls and retry once against the current DOM.
+        toggle = page.locator("#filterToggleBtn")
+        filter_panel = page.locator("#filterCollapse")
+        expect(toggle).to_be_visible()
+        if re.search(r"\bhidden\b", filter_panel.get_attribute("class") or ""):
+            toggle.click(force=True)
+        expect(filter_panel).not_to_have_class(re.compile(r"\bhidden\b"))
 
 
 def expect_filters_panel_closed(page):


### PR DESCRIPTION
## Summary

- harden the Playwright filter-panel helper against an HTMX toolbar/list swap race
- re-resolve the filter toggle and panel and retry once when the first click does not open the current panel

## Root cause

The beta release prepare run failed after resetting visible columns because the next filter-panel open could race against the refreshed toolbar DOM. The first click could target stale/current controls while the panel remained `hidden py-2`, causing the helper assertion to time out.

## Validation

- `./runproj exec --command "./runtests --playwright src/tests/playwright/test_filter_favourites.py::test_saved_favourite_restores_visible_columns"`
- `./runproj exec --command "./runtests --playwright src/tests/playwright/test_filter_favourites.py"`
- `./runproj exec --command "./runtests --playwright src/tests/playwright/test_filter_favourites.py::test_saved_favourite_restores_visible_columns src/tests/playwright/test_filter_favourites.py"`
- `git diff --check`