### PR TITLE
ci(security): ignore npm bundled undici trivy finding

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           image-ref: django-powercrud:${{ github.sha }}
           format: table
+          trivyignores: .trivyignore.yaml
           vuln-type: os,library
           severity: HIGH,CRITICAL
           ignore-unfixed: true
@@ -63,6 +64,7 @@ jobs:
         with:
           image-ref: django-powercrud:${{ github.sha }}
           format: table
+          trivyignores: .trivyignore.yaml
           vuln-type: os,library
           severity: HIGH,CRITICAL
           ignore-unfixed: true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,9 @@
+vulnerabilities:
+  - id: CVE-2026-12151
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/undici/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal undici in the dev/test Docker image. This is not a
+      PowerCRUD runtime dependency, project package-lock dependency, or PyPI
+      package artifact. Remove once pinned npm bundles undici >= 6.27.0.

--- a/docs/_plans/dependency_security/dependency_security-notes.md
+++ b/docs/_plans/dependency_security/dependency_security-notes.md
@@ -61,7 +61,10 @@ Add simple, low-maintenance CI security checks for dependency and container risk
 - Docker image fix applied on `security/dependency-hardening`: move NodeSource from `node_20.x` to `node_22.x`.
 - Follow-up image fix applied on `security/dependency-hardening`: pin global npm to `11.17.0`, which bundles `picomatch` `4.0.4`.
 - Validation passed on PR #140: Trivy filesystem and image scans report 0 vulnerabilities for the configured `HIGH,CRITICAL` scan set.
-- No Trivy allowlist is currently needed.
+- PR #165 later found `CVE-2026-12151` in `usr/lib/node_modules/npm/node_modules/undici/package.json` from npm's bundled internal dependencies inside the Docker image.
+- The finding is not from this repo's `package-lock.json`, not a PowerCRUD runtime dependency, and not included in the PyPI package artifacts.
+- A path-scoped `.trivyignore.yaml` exception now suppresses only `CVE-2026-12151` for npm's bundled `undici` path, expiring on 2026-09-30.
+- Remove the exception once the pinned global npm release bundles `undici >= 6.27.0`.
 
 ## Deferred
 


### PR DESCRIPTION
## Summary

- Add a path-scoped Trivy ignore for `CVE-2026-12151` only at `usr/lib/node_modules/npm/node_modules/undici/package.json`.
- Wire the Docker image Trivy scans to use `.trivyignore.yaml`.
- Record the rationale, expiry, and removal condition in the dependency security notes.

## Rationale

Trivy is finding `undici` `6.26.0` inside npm's bundled internal dependency tree in the dev/test Docker image: `usr/lib/node_modules/npm/node_modules/undici/package.json`.

This is not coming from this repo's `package-lock.json`, is not a PowerCRUD Python runtime dependency, and is not included in the PyPI package artifacts. `npm@11.17.0` is currently the pinned global npm release in the Docker image, so the practical short-term response is a narrow, temporary exception rather than weakening the Trivy gate or treating this as a package release risk.

The ignore is intentionally limited to `CVE-2026-12151` at that npm-internal path, expires on `2026-09-30`, and should be removed once the pinned npm release bundles `undici >= 6.27.0`.

## Verification

- `git diff --check`
- YAML syntax check via Ruby's standard `yaml` parser
