### PR TITLE
Release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ During the `0.x` series, breaking changes can occur, although we try to minimise
 
 Version numbers below correspond to published git tags. The more important releases include a little extra narrative and upgrade context; smaller patch releases remain deliberately brief. For full detail between any two versions, use the GitHub compare view for the matching tags.
 
+## 0.8.3 (2026-07-06)
+- **Feature (pagination)**: add page size controls
+  
+  Adds configurable page-size options for list views, allowing projects to replace the default choices and disable the `All` option where unbounded result sets are inappropriate. The sample app now demonstrates a constrained pagination menu, and the new settings are documented in the configuration reference and examples.
+
 ## 0.8.2 (2026-06-26)
 - **Feature (favourites)**: add filter favourite owner resolver
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-powercrud"
-version = "0.8.2"
+version = "0.8.3"
 description = "Advanced CRUD for perfectionists with deadlines. An opinionated Neapolitan extension, with sprinkles."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "django-powercrud"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "django-htmx" },


### PR DESCRIPTION
## Summary

- Publish release 0.8.3 through the protected-main release workflow.
- Update version, lockfile, changelog, and built assets prepared by new_release.sh.

## Verification

- new_release.sh prepare validation completed.
- Required GitHub checks will run on this PR before merge.