### PR TITLE
Split package dependency review gates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,8 +71,8 @@ jobs:
           exit-code: 1
           skip-setup-trivy: true
 
-  dependency-review:
-    name: Dependency Review
+  dependency-review-runtime:
+    name: Dependency Review / Runtime Package
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -85,6 +85,25 @@ jobs:
         uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
+          fail-on-scopes: runtime
+          license-check: false
+
+  dependency-review-dev-local:
+    name: Dependency Review / Dev and Local Repo
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Review development and local dependency changes
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high
+          fail-on-scopes: development, unknown
           license-check: false
 
   socket-firewall:

--- a/docs/_plans/index.md
+++ b/docs/_plans/index.md
@@ -10,5 +10,6 @@ Keep active plans under `docs/_plans/<feature>/`, and promote anything worth kee
 
 - [Abstract Surface](abstract_surface/abstract_surface-plan.md)
 - [List Options](list_options/list_options-plan.md)
+- [Package Release Gates](package_release_gates/package_release_gates-plan.md)
 - [Power Actions](power_actions/power_actions-plan.md)
 - [Template Packs](template_packs/template_packs-master-plan.md)

--- a/docs/_plans/package_release_gates/package_release_gates-notes.md
+++ b/docs/_plans/package_release_gates/package_release_gates-notes.md
@@ -1,0 +1,77 @@
+# Package Release Gates Notes
+
+## Goal
+
+Protect the PyPI package from untested code and newly introduced dependency risk without letting unrelated Docker image findings block normal package work.
+
+## Current Situation
+
+- `main` is protected by an active GitHub ruleset.
+- PRs are required before changes can merge to `main`.
+- Status checks are required, but the observed required PR checks were the test matrix and Playwright smoke checks.
+- The Security workflow runs on pull requests and on pushes to `main`.
+- The Security workflow currently mixes package-relevant checks with Docker-image checks.
+
+## Important Distinction
+
+The package release risk is not the same as the Docker image risk.
+
+Package-relevant checks:
+
+- Python/Django test matrix.
+- Playwright smoke checks for packaged frontend/runtime behaviour.
+- GitHub `Dependency Review`, because it reviews dependency changes introduced by a PR.
+- Possibly `Socket Firewall`, because the package includes frontend assets and npm install behaviour can expose supply-chain risk.
+
+Less relevant to PyPI package gating:
+
+- Docker image OS/package vulnerability scanning.
+- Vulnerabilities from globally installed Docker image tooling that is not included in the published Python package.
+
+## Plan Phases
+
+### Phase A: Decide Merge Gates
+
+The safest small step is to keep tests required and consider making `Dependency Review` required.
+
+`Dependency Review` is the best first security gate because it is PR-native and focused on dependency changes. It should be less likely to block unrelated code changes than a full image scanner.
+
+`Socket Firewall` may be useful, but it should be observed for stability before making it a hard gate.
+
+Docker-image scanning should not be a required package merge gate unless the project explicitly wants container deployment health to block all package work.
+
+### Phase B: Split Security Signal
+
+The current Security workflow has useful checks, but the policy boundary is blurry because the job set combines package dependency checks and image scanning.
+
+A clearer setup would make the check names match their policy meaning:
+
+- `Dependency Review`: package dependency gate candidate.
+- `Socket Firewall`: npm supply-chain gate candidate.
+- `Trivy Filesystem`: package/repo dependency scan candidate, if stable and scoped.
+- `Trivy Docker Image`: advisory, scheduled, or deployment-specific.
+
+This would let the `main` ruleset require package-relevant checks without requiring Docker-image findings.
+
+### Phase C: Align Release Safety
+
+If the real concern is "do not publish a bad package", the release workflow should also run the package-relevant gates before publishing.
+
+The current release workflow already reruns the test matrix for release tags. The open policy question is whether release publishing should also require dependency/security checks that reflect PyPI package risk.
+
+### Phase D: Remove Redundant Main Push Work
+
+The workflows currently rerun after merge because they are configured for both `pull_request` and `push` to `main`.
+
+If PR checks are required and branches must be current enough before merging, rerunning the same tests after the squash merge is mostly redundant.
+
+Scheduled security scans should probably stay because vulnerability databases change even when code does not.
+
+Do not remove post-merge checks until the required PR checks and release gates are agreed.
+
+## Open Questions
+
+- Should `Dependency Review` become required immediately?
+- Should `Socket Firewall` remain advisory until it has a longer stability record?
+- Should Trivy be split into filesystem and Docker-image jobs before any Trivy check is required?
+- Should release publishing require dependency checks in addition to the existing release test matrix?

--- a/docs/_plans/package_release_gates/package_release_gates-notes.md
+++ b/docs/_plans/package_release_gates/package_release_gates-notes.md
@@ -4,6 +4,12 @@
 
 Protect the PyPI package from untested code and newly introduced dependency risk without letting unrelated Docker image findings block normal package work.
 
+The current recommendation is to improve package gates incrementally rather than making every security signal a hard blocker at once.
+
+The next implementation slice should be small: split `Dependency Review` into a required runtime-package check and an advisory dev/local-repo check.
+
+Implementation status: the Security workflow should expose `Dependency Review / Runtime Package` as the required candidate and `Dependency Review / Dev and Local Repo` as an advisory signal. The `protect_main` ruleset still needs to be updated after the new check names are visible from a PR run.
+
 ## Current Situation
 
 - `main` is protected by an active GitHub ruleset.
@@ -11,6 +17,9 @@ Protect the PyPI package from untested code and newly introduced dependency risk
 - Status checks are required, but the observed required PR checks were the test matrix and Playwright smoke checks.
 - The Security workflow runs on pull requests and on pushes to `main`.
 - The Security workflow currently mixes package-relevant checks with Docker-image checks.
+- The active `protect_main` ruleset requires the Python/Django test matrix and Playwright smoke checks, but not `Dependency Review`.
+- Recent Security and Pull Request Tests workflow runs were green on PR and `main` push events.
+- GitHub Dependency Review can filter by dependency scope, but it does not directly know this repo's Hatch wheel boundary.
 
 ## Important Distinction
 
@@ -20,8 +29,13 @@ Package-relevant checks:
 
 - Python/Django test matrix.
 - Playwright smoke checks for packaged frontend/runtime behaviour.
-- GitHub `Dependency Review`, because it reviews dependency changes introduced by a PR.
-- Possibly `Socket Firewall`, because the package includes frontend assets and npm install behaviour can expose supply-chain risk.
+- GitHub `Dependency Review / Runtime Package`, because it reviews runtime dependency changes introduced by a PR.
+- Possibly `Socket Firewall`, because the package includes frontend assets and npm install behaviour can expose supply-chain risk. This remains advisory for now.
+
+Local repo and sample-app checks:
+
+- `Dependency Review / Dev and Local Repo`, because optional, development, docs, test, and npm dependencies can affect contributors or users running the sample app locally.
+- This check should be visible but not required at first.
 
 Less relevant to PyPI package gating:
 
@@ -32,11 +46,13 @@ Less relevant to PyPI package gating:
 
 ### Phase A: Decide Merge Gates
 
-The safest small step is to keep tests required and consider making `Dependency Review` required.
+The safest small step is to keep tests required and make only the runtime-package dependency review required.
 
-`Dependency Review` is the best first security gate because it is PR-native and focused on dependency changes. It should be less likely to block unrelated code changes than a full image scanner.
+`Dependency Review / Runtime Package` is the best first security gate because it is PR-native and focused on dependency changes that affect normal package consumers. It should fail on high-severity runtime dependency additions.
 
-`Socket Firewall` may be useful, but it should be observed for stability before making it a hard gate.
+`Dependency Review / Dev and Local Repo` should run separately for development and unknown scopes, but it should remain advisory. It covers useful risk for people running the repo locally or trying the sample app without turning every dev-tool issue into a package merge blocker.
+
+`Socket Firewall` may be useful, but it should not become a hard gate yet. PowerCRUD package work should not have to wait for a formal 7-day pass window before normal PRs can merge. Treat Socket as advisory signal first, then decide later whether its stability and value justify making it required.
 
 Docker-image scanning should not be a required package merge gate unless the project explicitly wants container deployment health to block all package work.
 
@@ -46,18 +62,25 @@ The current Security workflow has useful checks, but the policy boundary is blur
 
 A clearer setup would make the check names match their policy meaning:
 
-- `Dependency Review`: package dependency gate candidate.
+- `Dependency Review / Runtime Package`: required package dependency gate.
+- `Dependency Review / Dev and Local Repo`: advisory local contributor/sample-app signal.
 - `Socket Firewall`: npm supply-chain gate candidate.
 - `Trivy Filesystem`: package/repo dependency scan candidate, if stable and scoped.
 - `Trivy Docker Image`: advisory, scheduled, or deployment-specific.
 
 This would let the `main` ruleset require package-relevant checks without requiring Docker-image findings.
 
+Do not make any Trivy check required while filesystem/package and Docker-image findings are bundled under a single practical policy decision.
+
+Dependency Review scope filtering is a pragmatic split, not a perfect shipped-artifact model. In this repo, npm packages are development dependencies, but built frontend assets can still ship inside `src/powercrud`. Treat that frontend asset supply-chain question as a deferred Socket or separate frontend-gate decision rather than overloading the first Dependency Review split.
+
 ### Phase C: Align Release Safety
 
 If the real concern is "do not publish a bad package", the release workflow should also run the package-relevant gates before publishing.
 
-The current release workflow already reruns the test matrix for release tags. The open policy question is whether release publishing should also require dependency/security checks that reflect PyPI package risk.
+The current release workflow already reruns the test matrix for release tags. The first release-safety layer should be release PRs passing the required PR gates plus the tag-time test matrix already in `publish.yml`.
+
+Do not add Docker-image scanning to the release publish path. Defer release-tag dependency/security jobs until the required PR gates have settled and there is still a concrete release-only gap to close.
 
 ### Phase D: Remove Redundant Main Push Work
 
@@ -69,9 +92,17 @@ Scheduled security scans should probably stay because vulnerability databases ch
 
 Do not remove post-merge checks until the required PR checks and release gates are agreed.
 
+## Deferred Decisions
+
+- Whether `Socket Firewall` should become required after a stable record across dependency PRs.
+- Whether any split Trivy filesystem/package check is stable and package-relevant enough to require.
+- Whether Docker image scanning needs a separate deployment policy outside the PyPI package release path.
+- Whether release tags need additional dependency/security jobs after PR gates are stable.
+- Whether shipped frontend asset supply-chain risk needs a separate gate beyond Dependency Review scopes.
+
 ## Open Questions
 
-- Should `Dependency Review` become required immediately?
-- Should `Socket Firewall` remain advisory until it has a longer stability record?
+- Should `Dependency Review / Runtime Package` be added to `protect_main` in the same PR as the Security workflow split?
+- What level of Socket Firewall failure history would justify promoting it later?
 - Should Trivy be split into filesystem and Docker-image jobs before any Trivy check is required?
-- Should release publishing require dependency checks in addition to the existing release test matrix?
+- Should release publishing require dependency checks in addition to the existing release test matrix after PR gates are stable?

--- a/docs/_plans/package_release_gates/package_release_gates-plan.md
+++ b/docs/_plans/package_release_gates/package_release_gates-plan.md
@@ -2,33 +2,44 @@
 
 ## Status
 
-Draft plan created. No workflow or ruleset changes have been made.
+Dependency Review split implementation started. Runtime-package dependency review is intended to become the only new required merge gate.
 
 ## Next
 
-Decide which dependency/security checks should block PR merge and which should remain advisory or release-only.
+Split `Dependency Review` into one required runtime-package check and one advisory dev/local-repo check. Leave Socket, Trivy, Docker image scanning, and release-tag security changes deferred.
 
 ## Phase A: Decide Merge Gates
 
-1. [ ] Keep the existing test matrix and Playwright smoke checks as required PR checks.
-2. [ ] Decide whether `Dependency Review` should become a required PR check.
-3. [ ] Decide whether `Socket Firewall` should become a required PR check or remain advisory.
-4. [ ] Keep Docker-image scanning out of package merge gates unless a separate deployment policy needs it.
+1. [x] Keep the existing test matrix and Playwright smoke checks as required PR checks.
+2. [ ] Add `Dependency Review / Runtime Package` as the required dependency check for PR merge.
+3. [x] Keep `Dependency Review / Dev and Local Repo` advisory for local sample-app, test, docs, and contributor tooling risk.
+4. [x] Keep `Socket Firewall` advisory for now; do not require a formal 7-day pass window before ordinary PowerCRUD package work can merge.
+5. [x] Keep Docker-image scanning out of package merge gates unless a separate deployment policy needs it.
 
 ## Phase B: Split Security Signal
 
-1. [ ] Separate package dependency checks from Docker image checks in workflow naming and policy.
-2. [ ] Keep package-relevant dependency checks easy to require in the `main` ruleset.
-3. [ ] Keep Docker-image vulnerability checks advisory, scheduled, or deployment-specific.
+1. [x] Configure `Dependency Review / Runtime Package` for runtime dependency scope and high-severity failures.
+2. [x] Configure `Dependency Review / Dev and Local Repo` for development and unknown dependency scopes, but do not require it.
+3. [ ] Keep package-relevant dependency checks easy to require in the `main` ruleset.
+4. [x] Keep Docker-image vulnerability checks advisory, scheduled, or deployment-specific.
+5. [x] Keep Trivy checks non-required until filesystem/package and Docker-image results are separated and reviewed.
 
 ## Phase C: Align Release Safety
 
-1. [ ] Decide whether package-relevant dependency checks should run before publishing a release tag.
+1. [ ] Rely on release PR gates plus the existing tag-time test matrix as the first release-safety layer.
 2. [ ] Ensure the release workflow blocks publishing on test failures.
 3. [ ] Ensure release blocking checks match the actual PyPI package risk, not unrelated container risk.
+4. [ ] Defer adding release-tag dependency/security jobs until the PR gates are stable and a concrete gap remains.
 
 ## Phase D: Remove Redundant Main Push Work
 
 1. [ ] Decide whether PR checks are strong enough to stop rerunning the same test workflow on `main` pushes.
 2. [ ] Keep scheduled security scans for changing vulnerability databases.
 3. [ ] Remove only redundant post-merge checks after the PR and release gates are agreed.
+
+## Deferred Until Later
+
+1. [ ] Decide whether `Socket Firewall` should become required after it has a stable record across dependency PRs.
+2. [ ] Decide whether any split Trivy filesystem/package check should become required.
+3. [ ] Decide whether Docker image scanning needs a separate deployment gate outside the PyPI package merge path.
+4. [ ] Decide whether shipped frontend asset supply-chain risk needs a separate gate beyond Dependency Review scopes.

--- a/docs/_plans/package_release_gates/package_release_gates-plan.md
+++ b/docs/_plans/package_release_gates/package_release_gates-plan.md
@@ -1,0 +1,34 @@
+# Package Release Gates Plan
+
+## Status
+
+Draft plan created. No workflow or ruleset changes have been made.
+
+## Next
+
+Decide which dependency/security checks should block PR merge and which should remain advisory or release-only.
+
+## Phase A: Decide Merge Gates
+
+1. [ ] Keep the existing test matrix and Playwright smoke checks as required PR checks.
+2. [ ] Decide whether `Dependency Review` should become a required PR check.
+3. [ ] Decide whether `Socket Firewall` should become a required PR check or remain advisory.
+4. [ ] Keep Docker-image scanning out of package merge gates unless a separate deployment policy needs it.
+
+## Phase B: Split Security Signal
+
+1. [ ] Separate package dependency checks from Docker image checks in workflow naming and policy.
+2. [ ] Keep package-relevant dependency checks easy to require in the `main` ruleset.
+3. [ ] Keep Docker-image vulnerability checks advisory, scheduled, or deployment-specific.
+
+## Phase C: Align Release Safety
+
+1. [ ] Decide whether package-relevant dependency checks should run before publishing a release tag.
+2. [ ] Ensure the release workflow blocks publishing on test failures.
+3. [ ] Ensure release blocking checks match the actual PyPI package risk, not unrelated container risk.
+
+## Phase D: Remove Redundant Main Push Work
+
+1. [ ] Decide whether PR checks are strong enough to stop rerunning the same test workflow on `main` pushes.
+2. [ ] Keep scheduled security scans for changing vulnerability databases.
+3. [ ] Remove only redundant post-merge checks after the PR and release gates are agreed.

--- a/src/powercrud/mixins/form_mixin.py
+++ b/src/powercrud/mixins/form_mixin.py
@@ -9,8 +9,6 @@ from django.http import HttpResponseRedirect, QueryDict
 from django.shortcuts import render
 from django.urls import reverse
 
-from urllib.parse import urlencode
-
 try:  # Optional dependency: crispy-forms
     from crispy_forms.helper import FormHelper
 except ImportError:  # pragma: no cover - environments without crispy_forms
@@ -18,6 +16,10 @@ except ImportError:  # pragma: no cover - environments without crispy_forms
 from neapolitan.views import Role
 from powercrud.labels import resolve_field_label
 from powercrud.logging import get_logger
+from powercrud.query_params import (
+    build_navigation_query_string,
+    build_navigation_querydict,
+)
 from .config_mixin import ConfigMixin, resolve_config
 
 log = get_logger(__name__)
@@ -909,13 +911,9 @@ class FormMixin:
                     for value in v:
                         filter_params.appendlist(real_key, value)
 
-            # Build canonical list URL with current filter/sort params
-            clean_params = {}
-            for k, v in filter_params.lists():
-                # filter out keys with no values
-                if v:
-                    clean_params[k] = v[-1]
+            filter_params = build_navigation_querydict(filter_params)
 
+            # Build canonical list URL with current filter/sort params
             # determine the canonical url that includes the filter parameters
             if self.namespace:
                 list_url_name = f"{self.namespace}:{self.url_base}-list"
@@ -923,8 +921,8 @@ class FormMixin:
                 list_url_name = f"{self.url_base}-list"
             list_path = reverse(list_url_name)
 
-            if clean_params:
-                canonical_query = urlencode(clean_params)
+            canonical_query = build_navigation_query_string(filter_params)
+            if canonical_query:
                 canonical_url = f"{list_path}?{canonical_query}"
             else:
                 canonical_url = list_path

--- a/src/powercrud/mixins/htmx_mixin.py
+++ b/src/powercrud/mixins/htmx_mixin.py
@@ -13,6 +13,7 @@ from django.template.response import TemplateResponse
 import json
 from neapolitan.views import Role
 from powercrud.logging import get_logger
+from powercrud.query_params import build_navigation_query_string
 from .config_mixin import resolve_config
 
 log = get_logger(__name__)
@@ -332,16 +333,8 @@ class HtmxMixin:
 
             # Only set HX-Push-Url for GET requests and when role is LIST
             if self.request.method == "GET" and self.role == Role.LIST:
-                clean_params: list[tuple[str, str]] = []
-                for k in self.request.GET:
-                    values = self.request.GET.getlist(k)
-                    clean_params.extend(
-                        (k, value) for value in values if str(value).strip()
-                    )
-                if clean_params:
-                    from urllib.parse import urlencode
-
-                    canonical_query = urlencode(clean_params, doseq=True)
+                canonical_query = build_navigation_query_string(self.request.GET)
+                if canonical_query:
                     canonical_url = f"{self.request.path}?{canonical_query}"
                 else:
                     canonical_url = self.request.path

--- a/src/powercrud/query_params.py
+++ b/src/powercrud/query_params.py
@@ -1,0 +1,60 @@
+"""Helpers for building safe PowerCRUD navigation query strings."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+from urllib.parse import urlencode
+
+from django.http import QueryDict
+
+NON_NAVIGATION_QUERY_PARAM_NAMES = frozenset({"csrfmiddlewaretoken"})
+
+
+def _iter_query_values(query_data: Any) -> Iterable[tuple[str, list[Any]]]:
+    """Yield query names and value lists from QueryDict-like or dict-like data."""
+    if not query_data:
+        return
+    if hasattr(query_data, "lists"):
+        yield from query_data.lists()
+        return
+    if hasattr(query_data, "items"):
+        for key, value in query_data.items():
+            if isinstance(value, (list, tuple)):
+                yield key, list(value)
+            else:
+                yield key, [value]
+
+
+def build_navigation_querydict(
+    query_data: Any,
+    *,
+    exclude: Iterable[str] = (),
+    drop_blank: bool = True,
+) -> QueryDict:
+    """Return a QueryDict safe to reflect into list/navigation URLs."""
+    ignored_names = NON_NAVIGATION_QUERY_PARAM_NAMES | frozenset(exclude)
+    query = QueryDict("", mutable=True)
+    for key, values in _iter_query_values(query_data):
+        if key in ignored_names:
+            continue
+        for value in values:
+            if drop_blank and not str(value).strip():
+                continue
+            query.appendlist(key, value)
+    return query
+
+
+def build_navigation_query_string(
+    query_data: Any,
+    *,
+    exclude: Iterable[str] = (),
+    drop_blank: bool = True,
+) -> str:
+    """Return a URL-encoded query string safe for browser navigation."""
+    query = build_navigation_querydict(
+        query_data,
+        exclude=exclude,
+        drop_blank=drop_blank,
+    )
+    return urlencode(list(query.lists()), doseq=True)

--- a/src/powercrud/templates/powercrud/daisyUI/object_list.html
+++ b/src/powercrud/templates/powercrud/daisyUI/object_list.html
@@ -388,7 +388,7 @@
                                 {% csrf_token %}
                                 <input type="hidden" name="list_view_url" value="{{ list_view_url }}">
                                 {% for key, values in request.GET.lists %}
-                                    {% if key != 'page' %}
+                                    {% if key != 'csrfmiddlewaretoken' and key != 'page' %}
                                         {% for value in values %}
                                             <input type="hidden" name="{{ key }}" value="{{ value }}">
                                         {% endfor %}
@@ -563,7 +563,7 @@
 
         <!-- Hidden fields to preserve current filter and sort parameters -->
         {% for key, values in request.GET.lists %}
-            {% if key != 'page_size' and key != 'page' and key != visible_filter_param_name %}
+            {% if key != 'csrfmiddlewaretoken' and key != 'page_size' and key != 'page' and key != visible_filter_param_name %}
                 {% for value in values %}
                     {% if filterset and key not in filterset.form.fields %}
                         <input type="hidden" name="{{ key }}" value="{{ value }}">

--- a/src/powercrud/templatetags/powercrud.py
+++ b/src/powercrud/templatetags/powercrud.py
@@ -30,6 +30,10 @@ from powercrud.cell_tooltips import (
 )
 from powercrud.labels import resolve_field_label, resolve_property_label
 from powercrud.logging import get_logger
+from powercrud.query_params import (
+    build_navigation_query_string,
+    build_navigation_querydict,
+)
 from powercrud.row_actions import (
     is_lazy_disabled_state_action,
     is_lazy_hidden_if_action,
@@ -734,7 +738,7 @@ def action_links(view: Any, object: Any) -> str:
     )
     query_string = ""
     if hasattr(view, "request") and hasattr(view.request, "GET") and view.request.GET:
-        query_string = view.request.GET.urlencode()
+        query_string = build_navigation_query_string(view.request.GET)
 
     default_target: str = _resolve_view_option(
         view,
@@ -1476,19 +1480,10 @@ def object_list(context, objects, view):
     current_sort = request.GET.get("sort", "") if request else ""
 
     # Get all current filter parameters
-    filter_params = request.GET.copy() if request else {}
-    if "sort" in filter_params:
-        filter_params.pop("sort")
-    if "page" in filter_params:
-        filter_params.pop("page")
-
-    # Only keep the last value for each key to avoid duplicate params in URLs
-    clean_params = {}
-    for k in filter_params:
-        clean_params[k] = filter_params.getlist(k)[-1]
-    filter_params = filter_params.__class__("", mutable=True)
-    for k, v in clean_params.items():
-        filter_params[k] = v
+    filter_params = build_navigation_querydict(
+        request.GET if request else {},
+        exclude={"sort", "page"},
+    )
 
     use_htmx = context.get("use_htmx", view.get_use_htmx())
     original_target = context.get("original_target", view.get_original_target())

--- a/src/tests/test_core_phase1.py
+++ b/src/tests/test_core_phase1.py
@@ -3854,6 +3854,42 @@ def test_powerfield_book_list_defers_poweraction_hidden_hook(client):
 
 
 @pytest.mark.django_db
+def test_book_list_htmx_push_url_strips_csrf_query_param(client):
+    """HTMX list navigation should not push submitted CSRF tokens into browser history."""
+    author = Author.objects.create(name="Canonical URL Author")
+    Book.objects.create(
+        title="Canonical URL",
+        author=author,
+        published_date=date(2024, 12, 2),
+        bestseller=False,
+        isbn="9876543210111",
+        pages=31,
+    )
+
+    _login_sample_manager(client)
+    response = client.get(
+        reverse("sample:bigbook-list"),
+        {
+            "page_size": "10",
+            "title": "Canonical",
+            "csrfmiddlewaretoken": "leaked-token",
+        },
+        HTTP_HX_REQUEST="true",
+        HTTP_HX_TARGET="content",
+    )
+
+    assert response.status_code == 200, (
+        "Sample book list should render successfully for an HTMX navigation request."
+    )
+    assert response["HX-Push-Url"] == (
+        f"{reverse('sample:bigbook-list')}?page_size=10&title=Canonical"
+    ), "HTMX list responses should preserve real list parameters but strip csrfmiddlewaretoken from the pushed URL."
+    assert "leaked-token" not in response.content.decode(), (
+        "List markup should not preserve a submitted CSRF token as hidden list-state input."
+    )
+
+
+@pytest.mark.django_db
 def test_book_selected_summary_uses_persisted_selection(client):
     """Render selected book details from the persisted bulk selection."""
     author = Author.objects.create(name="Summary Author")

--- a/src/tests/test_form_mixin_extended.py
+++ b/src/tests/test_form_mixin_extended.py
@@ -602,6 +602,54 @@ def test_form_valid_htmx_returns_list(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_form_valid_htmx_push_url_strips_preserved_csrf_filter(monkeypatch):
+    """HTMX form success should not push preserved CSRF filter parameters into history."""
+    author = Author.objects.create(name="Ada Filter")
+    book = Book.objects.create(
+        title="Async Filter",
+        author=author,
+        published_date="2024-01-01",
+        bestseller=False,
+        isbn="5555555550001",
+        pages=51,
+    )
+    request = attach_session(
+        RequestFactory().post(
+            "/",
+            {
+                "_powercrud_filter_page_size": "10",
+                "_powercrud_filter_title": "Async",
+                "_powercrud_filter_csrfmiddlewaretoken": "leaked-token",
+            },
+        )
+    )
+    request.htmx = SimpleNamespace()
+    view = DummyFormView(request)
+    view._object = book
+    view.object = book
+    view.role = Role.UPDATE
+
+    monkeypatch.setattr(
+        "powercrud.mixins.form_mixin.reverse", lambda name, kwargs=None: f"/{name}"
+    )
+    monkeypatch.setattr(view, "_check_for_conflicts", lambda selected_ids: False)
+
+    form = view.get_form_class()(
+        instance=book,
+        data={"title": "Async Filter", "author": author.pk, "published_date": "2024-01-01"},
+    )
+    assert form.is_valid(), (
+        "The form should validate before exercising HTMX success URL canonicalization."
+    )
+
+    response = view.form_valid(form)
+
+    assert response["HX-Push-Url"] == "/sample:book-list?page_size=10&title=Async", (
+        "HTMX form success should preserve real list state but strip csrfmiddlewaretoken from the pushed URL."
+    )
+
+
+@pytest.mark.django_db
 def test_form_valid_uses_persist_single_object_hook(monkeypatch):
     author = Author.objects.create(name="Grace")
     book = Book.objects.create(

--- a/src/tests/test_templatetags_powercrud.py
+++ b/src/tests/test_templatetags_powercrud.py
@@ -700,6 +700,34 @@ def test_action_links_disable_permission_denied_extra_action_before_row_state():
 
 
 @pytest.mark.django_db
+def test_action_links_strip_csrf_from_modal_query_string():
+    """Row-action links should not reflect CSRF tokens from current list state."""
+    author = Author.objects.create(name="Action CSRF Author")
+    book = Book.objects.create(
+        title="Action CSRF",
+        author=author,
+        published_date=date(2024, 1, 11),
+        bestseller=False,
+        isbn="9876543210010",
+        pages=42,
+        description="Preview exists",
+    )
+    request = apply_session(
+        RequestFactory().get("/?page_size=20&csrfmiddlewaretoken=leaked-token")
+    )
+    view = TemplateViewStub(request)
+
+    html = powercrud.action_links(view, book)
+
+    assert "csrfmiddlewaretoken" not in html, (
+        "Row-action links should strip csrfmiddlewaretoken from reflected list query strings."
+    )
+    assert "page_size=20" in html, (
+        "Row-action links should still preserve legitimate list query state for modal returns."
+    )
+
+
+@pytest.mark.django_db
 def test_action_links_evaluate_hidden_if_after_permission_passes():
     """Allowed extra actions should still use existing row hidden hooks."""
     author = Author.objects.create(name="Permission Hidden State")
@@ -998,7 +1026,9 @@ def test_object_list_renders_booleans_dates_and_selection():
         pages=15,
     )
     book.genres.add(genre)
-    request = apply_session(RequestFactory().get("/?sort=title&filter=1"))
+    request = apply_session(
+        RequestFactory().get("/?sort=title&filter=1&csrfmiddlewaretoken=leaked-token")
+    )
     request.session["selected"] = ["1"]
     view = TemplateViewStub(request)
 
@@ -1027,6 +1057,9 @@ def test_object_list_renders_booleans_dates_and_selection():
     assert result["selected_ids"] == ["1"]
     assert result["selected_count"] == 1
     assert result["filter_params"] == "filter=1"
+    assert "csrfmiddlewaretoken" not in result["filter_params"], (
+        "Object-list filter params should not reflect CSRF tokens into sort/filter URLs."
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Split Dependency Review into a runtime-package gate and an advisory dev/local repo signal.
- Keep Socket Firewall, Trivy, Docker image scanning, and release-tag security changes deferred.
- Update the package release-gates plan to reflect the agreed next implementation slice.

## Verification

- `git diff --check`

## Follow-up in this PR flow

After this PR exposes the new check names, update `protect_main` to require only `Dependency Review / Runtime Package` in addition to the existing test matrix and Playwright smoke checks.
