### PR TITLE
Remove redundant main push checks

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -1,8 +1,6 @@
 name: Pull Request Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,8 +2,6 @@ name: Security
 
 on:
   pull_request:
-  push:
-    branches: [ main ]
   schedule:
     - cron: "22 2 * * 1"
   workflow_dispatch:

--- a/docs/_plans/package_release_gates/package_release_gates-notes.md
+++ b/docs/_plans/package_release_gates/package_release_gates-notes.md
@@ -8,7 +8,7 @@ The current recommendation is to improve package gates incrementally rather than
 
 The next implementation slice should be small: split `Dependency Review` into a required runtime-package check and an advisory dev/local-repo check.
 
-Implementation status: the Security workflow should expose `Dependency Review / Runtime Package` as the required candidate and `Dependency Review / Dev and Local Repo` as an advisory signal. The `protect_main` ruleset still needs to be updated after the new check names are visible from a PR run.
+Implementation status: the Security workflow exposes `Dependency Review / Runtime Package` as the required gate and `Dependency Review / Dev and Local Repo` as an advisory signal. The `protect_main` ruleset requires the runtime-package check along with the existing test matrix and Playwright smoke checks.
 
 ## Current Situation
 
@@ -91,6 +91,8 @@ If PR checks are required and branches must be current enough before merging, re
 Scheduled security scans should probably stay because vulnerability databases change even when code does not.
 
 Do not remove post-merge checks until the required PR checks and release gates are agreed.
+
+Phase D removes only the redundant `push` to `main` triggers from the PR Tests and Security workflows. Pull-request checks remain required, Security keeps its scheduled and manual triggers, and tag-based release workflows remain unchanged.
 
 ## Deferred Decisions
 

--- a/docs/_plans/package_release_gates/package_release_gates-plan.md
+++ b/docs/_plans/package_release_gates/package_release_gates-plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Dependency Review split implementation started. Runtime-package dependency review is intended to become the only new required merge gate.
+Runtime-package dependency review is now the only new required merge gate. Phase D cleanup is removing redundant post-merge test/security reruns.
 
 ## Next
 
@@ -11,7 +11,7 @@ Split `Dependency Review` into one required runtime-package check and one adviso
 ## Phase A: Decide Merge Gates
 
 1. [x] Keep the existing test matrix and Playwright smoke checks as required PR checks.
-2. [ ] Add `Dependency Review / Runtime Package` as the required dependency check for PR merge.
+2. [x] Add `Dependency Review / Runtime Package` as the required dependency check for PR merge.
 3. [x] Keep `Dependency Review / Dev and Local Repo` advisory for local sample-app, test, docs, and contributor tooling risk.
 4. [x] Keep `Socket Firewall` advisory for now; do not require a formal 7-day pass window before ordinary PowerCRUD package work can merge.
 5. [x] Keep Docker-image scanning out of package merge gates unless a separate deployment policy needs it.
@@ -20,22 +20,22 @@ Split `Dependency Review` into one required runtime-package check and one adviso
 
 1. [x] Configure `Dependency Review / Runtime Package` for runtime dependency scope and high-severity failures.
 2. [x] Configure `Dependency Review / Dev and Local Repo` for development and unknown dependency scopes, but do not require it.
-3. [ ] Keep package-relevant dependency checks easy to require in the `main` ruleset.
+3. [x] Keep package-relevant dependency checks easy to require in the `main` ruleset.
 4. [x] Keep Docker-image vulnerability checks advisory, scheduled, or deployment-specific.
 5. [x] Keep Trivy checks non-required until filesystem/package and Docker-image results are separated and reviewed.
 
 ## Phase C: Align Release Safety
 
-1. [ ] Rely on release PR gates plus the existing tag-time test matrix as the first release-safety layer.
-2. [ ] Ensure the release workflow blocks publishing on test failures.
-3. [ ] Ensure release blocking checks match the actual PyPI package risk, not unrelated container risk.
-4. [ ] Defer adding release-tag dependency/security jobs until the PR gates are stable and a concrete gap remains.
+1. [x] Rely on release PR gates plus the existing tag-time test matrix as the first release-safety layer.
+2. [x] Ensure the release workflow blocks publishing on test failures.
+3. [x] Ensure release blocking checks match the actual PyPI package risk, not unrelated container risk.
+4. [x] Defer adding release-tag dependency/security jobs until the PR gates are stable and a concrete gap remains.
 
 ## Phase D: Remove Redundant Main Push Work
 
-1. [ ] Decide whether PR checks are strong enough to stop rerunning the same test workflow on `main` pushes.
-2. [ ] Keep scheduled security scans for changing vulnerability databases.
-3. [ ] Remove only redundant post-merge checks after the PR and release gates are agreed.
+1. [x] Decide whether PR checks are strong enough to stop rerunning the same test workflow on `main` pushes.
+2. [x] Keep scheduled security scans for changing vulnerability databases.
+3. [x] Remove only redundant post-merge checks after the PR and release gates are agreed.
 
 ## Deferred Until Later
 


### PR DESCRIPTION
## Summary

- Remove redundant post-merge `push: main` runs from PR Tests and Security.
- Keep pull request validation, scheduled Security scans, manual Security runs, and tag-based release workflows intact.
- Mark the release-gates plan through Phase D while keeping Socket, Trivy, Docker hard gates, and frontend supply-chain policy deferred.

## Verification

- `git diff --check`
- PR 181 required checks passed before this cleanup branch was created.
- `protect_main` now requires `Dependency Review / Runtime Package` plus the existing test matrix and Playwright smoke checks.
