### PR TITLE
fix(deps): manage uv dependencies with Renovate PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ tests-core = [
     "django-q2>=1.9.0,<2",
     "psycopg-binary>=3.3.3,<4",
     "psycopg>=3.3.3,<4",
-    "django-redis>=6.0.0,<7",
+    "django-redis>=7,<8",
     "pytest-django>=4.12.0,<5",
 ]
 tests-ui = [
@@ -92,7 +92,7 @@ tests-core = [
     "django-q2>=1.9.0,<2",
     "psycopg-binary>=3.3.3,<4",
     "psycopg>=3.3.3,<4",
-    "django-redis>=6.0.0,<7",
+    "django-redis>=7,<8",
     "pytest-django>=4.12.0,<5",
 ]
 tests-ui = [

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
   "dependencyDashboardAutoclose": true,
   "platformAutomerge": false,
   "enabledManagers": [
-    "poetry",
+    "pep621",
     "npm",
     "dockerfile",
     "github-actions"
@@ -28,7 +28,7 @@
     {
       "description": "Group Python dependency updates.",
       "matchManagers": [
-        "poetry"
+        "pep621"
       ],
       "groupName": "python-packages",
       "groupSlug": "python-packages",
@@ -108,7 +108,7 @@
     {
       "description": "Keep django-crispy-forms within the declared range.",
       "matchManagers": [
-        "poetry"
+        "pep621"
       ],
       "matchPackageNames": [
         "django-crispy-forms"
@@ -118,7 +118,7 @@
     {
       "description": "Do not raise pytest major updates automatically.",
       "matchManagers": [
-        "poetry"
+        "pep621"
       ],
       "matchPackageNames": [
         "pytest"

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -567,7 +567,7 @@ requires-dist = [
     { name = "django-crispy-forms", marker = "extra == 'tests-core'", specifier = ">=2.5,<3" },
     { name = "django-htmx", specifier = ">=1.27.0,<2.0" },
     { name = "django-q2", marker = "extra == 'tests-core'", specifier = ">=1.9.0,<2" },
-    { name = "django-redis", marker = "extra == 'tests-core'", specifier = ">=6.0.0,<7" },
+    { name = "django-redis", marker = "extra == 'tests-core'", specifier = ">=7,<8" },
     { name = "django-template-partials", specifier = ">=25.3" },
     { name = "django-vite", marker = "extra == 'tests-core'", specifier = ">=3.1.0,<4" },
     { name = "faker", marker = "extra == 'tests-core'", specifier = ">=40.11,<41" },
@@ -604,7 +604,7 @@ tests-core = [
     { name = "django", specifier = ">=5.2,<7" },
     { name = "django-crispy-forms", specifier = ">=2.5,<3" },
     { name = "django-q2", specifier = ">=1.9.0,<2" },
-    { name = "django-redis", specifier = ">=6.0.0,<7" },
+    { name = "django-redis", specifier = ">=7,<8" },
     { name = "django-vite", specifier = ">=3.1.0,<4" },
     { name = "faker", specifier = ">=40.11,<41" },
     { name = "neapolitan", specifier = ">=26.1,<27" },
@@ -636,15 +636,16 @@ wheels = [
 
 [[package]]
 name = "django-redis"
-version = "6.0.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "redis" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/53/dbcfa1e528e0d6c39947092625b2c89274b5d88f14d357cee53c4d6dbbd4/django_redis-6.0.0.tar.gz", hash = "sha256:2d9cb12a20424a4c4dde082c6122f486628bae2d9c2bee4c0126a4de7fda00dd", size = 56904, upload-time = "2025-06-17T18:15:46.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/78/203a0cdc0f1c083a5407d01f77b58099a120bb8a5a04562f56a9bb341314/django_redis-7.0.0.tar.gz", hash = "sha256:e48491c862f4350b0747ceb1016700686fb93c4f4e0fb9c490fe6c6658ffd933", size = 64601, upload-time = "2026-06-02T14:17:48.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/79/055dfcc508cfe9f439d9f453741188d633efa9eab90fc78a67b0ab50b137/django_redis-6.0.0-py3-none-any.whl", hash = "sha256:20bf0063a8abee567eb5f77f375143c32810c8700c0674ced34737f8de4e36c0", size = 33687, upload-time = "2025-06-17T18:15:34.165Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9f/09cdb9a1eebe8533b02a7694ca787acfc1e4d93b5b6175ff99366d4e6d64/django_redis-7.0.0-py3-none-any.whl", hash = "sha256:4b23aa6e0cd0937bb1242e9a463809e6004de3ca2150f34e986306bb6220d688", size = 38932, upload-time = "2026-06-02T14:17:47.281Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1743,11 +1743,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- switch Renovate from the Poetry manager to the PEP 621 manager that maintains uv.lock
- keep published test extras and local dependency groups aligned on django-redis 7
- refresh uv.lock to django-redis 7.0.0

## Root cause

Renovate updated only the published extra while the mirrored uv dependency group and uv.lock retained the django-redis 6 constraint. This made uv project resolution unsatisfiable during the Docker build.

## Verification

- python -m json.tool renovate.json
- uv lock --check
- ./runproj exec --command "./runtests" (blocked locally: powercrud_django_dev is not running)