### PR TITLE
fix(urls): support favourites without async dependencies

### DIFF
--- a/src/powercrud/mixins/form_mixin.py
+++ b/src/powercrud/mixins/form_mixin.py
@@ -1037,7 +1037,9 @@ class FormMixin:
             # Restore original GET
             self.request.GET = original_get
 
-            response["HX-Trigger"] = json.dumps({"formSuccess": True})
+            trigger_data = json.loads(self.get_hx_trigger() or "{}")
+            trigger_data["formSuccess"] = True
+            response["HX-Trigger"] = json.dumps(trigger_data)
             response["HX-Retarget"] = f"{self.get_original_target()}"
             response["HX-Push-Url"] = canonical_url
             return response

--- a/src/powercrud/urls.py
+++ b/src/powercrud/urls.py
@@ -1,13 +1,14 @@
 from django.apps import apps
 from django.urls import include, path
 
-from .async_manager import AsyncManager
-
 app_name = "powercrud"  # Default namespace
 
-urlpatterns = [
-    AsyncManager.get_url(name="async_progress"),
-]
+urlpatterns = []
+
+if apps.is_installed("django_q"):
+    from .async_manager import AsyncManager
+
+    urlpatterns.append(AsyncManager.get_url(name="async_progress"))
 
 if apps.is_installed("powercrud.contrib.favourites"):
     urlpatterns.append(

--- a/src/tests/test_favourites_contrib.py
+++ b/src/tests/test_favourites_contrib.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +26,77 @@ from sample.views import BookCRUDView
 
 BOOK_VIEW_KEY = f"{BookCRUDView.__module__}.{BookCRUDView.__name__}"
 SESSION_FAVOURITE_OWNER_USERNAME = "powercrud_filter_favourite_owner_username"
+
+
+def test_shared_urls_support_favourites_without_async_dependencies():
+    """Shared URLs should expose favourites without importing django-q2."""
+
+    probe = """
+import sys
+import types
+
+import django
+from django.conf import settings
+
+
+sys.modules["django_q"] = None
+
+root_urls = types.ModuleType("favourites_without_async_probe_urls")
+root_urls.urlpatterns = []
+sys.modules[root_urls.__name__] = root_urls
+
+settings.configure(
+    SECRET_KEY="favourites-without-async-probe",
+    INSTALLED_APPS=(
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "powercrud",
+        "powercrud.contrib.favourites",
+    ),
+    DATABASES={
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    },
+    DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    ROOT_URLCONF=root_urls.__name__,
+)
+django.setup()
+
+from django.urls import clear_url_caches, include, path, reverse
+
+
+root_urls.urlpatterns = [
+    path("powercrud/", include("powercrud.urls", namespace="powercrud")),
+]
+clear_url_caches()
+
+expected_routes = {
+    "powercrud:favourites-toolbar": "/powercrud/favourites/toolbar/",
+    "powercrud:favourites-save": "/powercrud/favourites/save/",
+    "powercrud:favourites-apply": "/powercrud/favourites/apply/",
+    "powercrud:favourites-update": "/powercrud/favourites/update/",
+    "powercrud:favourites-delete": "/powercrud/favourites/delete/",
+}
+for route_name, expected_url in expected_routes.items():
+    actual_url = reverse(route_name)
+    assert actual_url == expected_url, (
+        f"Expected {route_name} to reverse to {expected_url}, got {actual_url}."
+    )
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        "A favourites-only project should load the documented shared PowerCRUD URLs "
+        f"without django-q2.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
 
 
 def resolve_filter_favourite_owner_from_session(request):

--- a/src/tests/test_form_mixin_extended.py
+++ b/src/tests/test_form_mixin_extended.py
@@ -646,6 +646,7 @@ def test_form_valid_htmx_returns_list(monkeypatch):
     view._object = book
     view.object = book
     view.role = Role.UPDATE
+    view.hx_trigger = {"measurementsChanged": True}
 
     monkeypatch.setattr(
         "powercrud.mixins.form_mixin.reverse", lambda name, kwargs=None: f"/{name}"
@@ -660,7 +661,13 @@ def test_form_valid_htmx_returns_list(monkeypatch):
     monkeypatch.setattr(view, "_check_for_conflicts", lambda selected_ids: False)
     response = view.form_valid(form)
     assert isinstance(response, HttpResponse)
-    assert json.loads(response["HX-Trigger"]) == {"formSuccess": True}
+    assert json.loads(response["HX-Trigger"]) == {
+        "measurementsChanged": True,
+        "formSuccess": True,
+    }, (
+        "HTMX form success should preserve configured trigger events alongside "
+        "PowerCRUD's formSuccess event."
+    )
     assert response["HX-Retarget"] == view.get_original_target()
 
 


### PR DESCRIPTION
Previously, powercrud.urls would import `AsyncManager` unilaterally even though not strictly required. This in turn meant any downstream implementation would then fail the requirement to have `django-q2` installed. This PR fixes that problem.