### PR TITLE
fix(ci): restore Trivy security baseline

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,52 @@
 vulnerabilities:
+  - id: CVE-2026-13149
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/brace-expansion/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal brace-expansion in the dev/test Docker image. This is not a
+      PowerCRUD runtime dependency, project package-lock dependency, or PyPI
+      package artifact. Remove once pinned npm bundles a fixed version.
+  - id: CVE-2026-14257
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/brace-expansion/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal brace-expansion in the dev/test Docker image. This is not a
+      PowerCRUD runtime dependency, project package-lock dependency, or PyPI
+      package artifact. Remove once pinned npm bundles a fixed version.
+  - id: CVE-2026-69152
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/brace-expansion/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal brace-expansion in the dev/test Docker image. This is not a
+      PowerCRUD runtime dependency, project package-lock dependency, or PyPI
+      package artifact. Remove once pinned npm bundles a fixed version.
+  - id: CVE-2026-69192
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/ip-address/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal ip-address in the dev/test Docker image. This is not a
+      PowerCRUD runtime dependency, project package-lock dependency, or PyPI
+      package artifact. Remove once pinned npm bundles a fixed version.
+  - id: CVE-2026-59873
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/tar/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal tar in the dev/test Docker image. This is not a PowerCRUD
+      runtime dependency, project package-lock dependency, or PyPI package
+      artifact. Remove once pinned npm bundles a fixed version.
+  - id: CVE-2026-59874
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/tar/package.json"
+    expired_at: 2026-09-30
+    statement: >-
+      npm-internal tar in the dev/test Docker image. This is not a PowerCRUD
+      runtime dependency, project package-lock dependency, or PyPI package
+      artifact. Remove once pinned npm bundles a fixed version.
   - id: CVE-2026-12151
     paths:
       - "usr/lib/node_modules/npm/node_modules/undici/package.json"

--- a/docker/dockerfile_django
+++ b/docker/dockerfile_django
@@ -4,6 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG PROJECT_DIR=django_powercrud
 ARG USER=devuser
 ARG USERHOME=/home/${USER}
+# renovate: datasource=npm depName=npm versioning=semver
 ARG NPM_VERSION=11.17.0
 ARG PLAYWRIGHT_VERSION=1.58.0
 ARG PROMPT_CODE='\n\[\e[0m\]🐳 \[\e[0m\][\[\e[0;38;5;226m\]$(git branch 2>/dev/null | grep '"'"'^*'"'"' | colrm 1 2)\[\e[0m\]] \[\e[0;91m\]\u\[\e[0m\]: \[\e[0;96m\]\w\n\[\e[0m\]\$\[\e[0m\] '

--- a/docker/dockerfile_django
+++ b/docker/dockerfile_django
@@ -51,7 +51,7 @@ ENV UV_PROJECT_ENVIRONMENT=/usr/local \
 # Install the pinned Playwright client and Chromium before general Python
 # dependencies so routine lockfile updates do not invalidate this costly layer.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system "playwright==${PLAYWRIGHT_VERSION}" && \
+    uv pip install --system "wheel==0.47.0" "playwright==${PLAYWRIGHT_VERSION}" && \
     python -m playwright install --with-deps chromium
 
 # Install locked Python dependencies separately from the project source so this

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -1195,9 +1195,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1215,7 +1215,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,20 @@
     "pep621",
     "npm",
     "dockerfile",
-    "github-actions"
+    "github-actions",
+    "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the global npm CLI in the development image.",
+      "managerFilePatterns": [
+        "/^docker\\/dockerfile_django$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>npm) depName=(?<depName>npm) versioning=(?<versioning>semver)\\s+ARG NPM_VERSION=(?<currentValue>\\S+)"
+      ]
+    }
   ],
   "packageRules": [
     {

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1742,11 +1742,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.9.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Restores the blocking Trivy baseline without weakening scan policy.

- refreshes project-owned PostCSS and setuptools locks
- installs wheel 0.47.0 explicitly in the development/test image
- makes the pinned global npm CLI Renovate-managed
- scopes six temporary npm-internal image findings to their exact package paths, expiring 2026-09-30

No public PowerCRUD API changes.

Verified: `./runproj exec --command "./runtests"` (1,059 passed; 95 deselected; 4 skipped).

Review focus: the Renovate regex annotation and the narrow Trivy exception paths.