### PR TITLE
chore(renovate): track Dockerfile wheel tooling

### DIFF
--- a/docker/dockerfile_django
+++ b/docker/dockerfile_django
@@ -6,6 +6,8 @@ ARG USER=devuser
 ARG USERHOME=/home/${USER}
 # renovate: datasource=npm depName=npm versioning=semver
 ARG NPM_VERSION=11.17.0
+# renovate: datasource=pypi depName=wheel versioning=pep440
+ARG WHEEL_VERSION=0.47.0
 ARG PLAYWRIGHT_VERSION=1.58.0
 ARG PROMPT_CODE='\n\[\e[0m\]🐳 \[\e[0m\][\[\e[0;38;5;226m\]$(git branch 2>/dev/null | grep '"'"'^*'"'"' | colrm 1 2)\[\e[0m\]] \[\e[0;91m\]\u\[\e[0m\]: \[\e[0;96m\]\w\n\[\e[0m\]\$\[\e[0m\] '
 
@@ -52,7 +54,7 @@ ENV UV_PROJECT_ENVIRONMENT=/usr/local \
 # Install the pinned Playwright client and Chromium before general Python
 # dependencies so routine lockfile updates do not invalidate this costly layer.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system "wheel==0.47.0" "playwright==${PLAYWRIGHT_VERSION}" && \
+    uv pip install --system "wheel==${WHEEL_VERSION}" "playwright==${PLAYWRIGHT_VERSION}" && \
     python -m playwright install --with-deps chromium
 
 # Install locked Python dependencies separately from the project source so this

--- a/renovate.json
+++ b/renovate.json
@@ -28,12 +28,12 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track the global npm CLI in the development image.",
+      "description": "Track annotated development-image tool versions.",
       "managerFilePatterns": [
         "/^docker\\/dockerfile_django$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>npm) depName=(?<depName>npm) versioning=(?<versioning>semver)\\s+ARG NPM_VERSION=(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+) versioning=(?<versioning>[^\\s]+)\\s+ARG [A-Z0-9_]+_VERSION=(?<currentValue>\\S+)"
       ]
     }
   ],


### PR DESCRIPTION
Makes the development-image wheel install Renovate-managed.

- promotes the wheel version to an annotated Dockerfile argument
- generalises the existing annotation manager to track both npm and PyPI tools
- preserves the existing npm behavior and all global patch/minor automerge gates

Verified: `./runproj exec --command "./runtests"` (1,059 selected tests passed; 95 deselected; 4 skipped).

Review focus: the manager is restricted to annotated `ARG *_VERSION` values in the development Dockerfile.