### PR TITLE
Avoid duplicate tests during release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,18 @@ jobs:
       version: ${{ steps.classify.outputs.version }}
       prerelease: ${{ steps.classify.outputs.prerelease }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify release tag belongs to main
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor HEAD refs/remotes/origin/main; then
+            echo "Release tag must point to a commit on main." >&2
+            exit 1
+          fi
+
       - name: Classify release tag
         id: classify
         env:
@@ -34,16 +46,8 @@ jobs:
               print(f"prerelease={'true' if prerelease else 'false'}", file=fh)
           PY
 
-  test-matrix:
-    needs: classify-tag
-    uses: ./.github/workflows/run_tests.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   release:
-    needs:
-      - classify-tag
-      - test-matrix
+    needs: classify-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/src/tests/test_release_policy.py
+++ b/src/tests/test_release_policy.py
@@ -42,6 +42,24 @@ def test_release_workflows_reject_rc_tags():
         )
 
 
+def test_publish_workflow_uses_pr_checks_without_repeating_test_matrix():
+    """Publishing should validate tag provenance without rerunning PR tests."""
+    publish_workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "publish.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "uses: ./.github/workflows/run_tests.yml" not in publish_workflow, (
+        "The tag workflow should not repeat the test matrix already required on the PR."
+    )
+    assert "fetch-depth: 0" in publish_workflow, (
+        "Tag provenance validation needs complete main history."
+    )
+    assert (
+        "git merge-base --is-ancestor HEAD refs/remotes/origin/main"
+        in publish_workflow
+    ), "The tag workflow should reject release commits that do not belong to main."
+
+
 def test_release_script_finalizes_prerelease_without_new_commits():
     """Final alpha/beta promotion should not fail only because no commits followed it."""
     release_script = (PROJECT_ROOT / "new_release.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- stop rerunning the complete Python/Django and Playwright matrix after a release tag is pushed
- require release tags to point to commits contained in protected `main`
- retain version validation, GitHub Release creation, package build, PyPI publishing, and documentation deployment
- add static release-policy coverage for the streamlined workflow

## Verification

- `./runproj exec --command "./runtests src/tests/test_release_policy.py"` (`4 passed`)
- `git diff --check`
